### PR TITLE
Bibliography normalization

### DIFF
--- a/plainnat_abbrv.bst
+++ b/plainnat_abbrv.bst
@@ -1,0 +1,1436 @@
+%% File: `plainnat.bst'
+%% A modification of `plain.bst' for use with natbib package
+%%
+%% Copyright 1993-2007 Patrick W Daly
+%% Max-Planck-Institut f\"ur Sonnensystemforschung
+%% Max-Planck-Str. 2
+%% D-37191 Katlenburg-Lindau
+%% Germany
+%% E-mail: daly@mps.mpg.de
+%%
+%% This program can be redistributed and/or modified under the terms
+%% of the LaTeX Project Public License Distributed from CTAN
+%% archives in directory macros/latex/base/lppl.txt; either
+%% version 1 of the License, or any later version.
+%%
+ % Version and source file information:
+ % \ProvidesFile{natbst.mbs}[2007/11/26 1.93 (PWD)]
+ %
+ % BibTeX `plainnat' family
+ %   version 0.99b for BibTeX versions 0.99a or later,
+ %   for LaTeX versions 2.09 and 2e.
+ %
+ % For use with the `natbib.sty' package; emulates the corresponding
+ %   member of the `plain' family, but with author-year citations.
+ %
+ % With version 6.0 of `natbib.sty', it may also be used for numerical
+ %   citations, while retaining the commands \citeauthor, \citefullauthor,
+ %   and \citeyear to print the corresponding information.
+ %
+ % For version 7.0 of `natbib.sty', the KEY field replaces missing
+ %   authors/editors, and the date is left blank in \bibitem.
+ %
+ % Includes field EID for the sequence/citation number of electronic journals
+ %  which is used instead of page numbers.
+ %
+ % Includes fields ISBN and ISSN.
+ %
+ % Includes field URL for Internet addresses.
+ %
+ % Includes field DOI for Digital Object Idenfifiers.
+ %
+ % Works best with the url.sty package of Donald Arseneau.
+ %
+ % Works with identical authors and year are further sorted by
+ %   citation key, to preserve any natural sequence.
+ %
+ENTRY
+  { address
+    author
+    booktitle
+    chapter
+    doi
+    eid
+    edition
+    editor
+    howpublished
+    institution
+    isbn
+    issn
+    journal
+    key
+    month
+    note
+    number
+    organization
+    pages
+    publisher
+    school
+    series
+    title
+    type
+    url
+    volume
+    year
+  }
+  {}
+  { label extra.label sort.label short.list }
+
+INTEGERS { output.state before.all mid.sentence after.sentence after.block }
+
+FUNCTION {init.state.consts}
+{ #0 'before.all :=
+  #1 'mid.sentence :=
+  #2 'after.sentence :=
+  #3 'after.block :=
+}
+
+STRINGS { s t }
+
+FUNCTION {output.nonnull}
+{ 's :=
+  output.state mid.sentence =
+    { ", " * write$ }
+    { output.state after.block =
+        { add.period$ write$
+          newline$
+          "\newblock " write$
+        }
+        { output.state before.all =
+            'write$
+            { add.period$ " " * write$ }
+          if$
+        }
+      if$
+      mid.sentence 'output.state :=
+    }
+  if$
+  s
+}
+
+FUNCTION {output}
+{ duplicate$ empty$
+    'pop$
+    'output.nonnull
+  if$
+}
+
+FUNCTION {output.check}
+{ 't :=
+  duplicate$ empty$
+    { pop$ "empty " t * " in " * cite$ * warning$ }
+    'output.nonnull
+  if$
+}
+
+FUNCTION {fin.entry}
+{ add.period$
+  write$
+  newline$
+}
+
+FUNCTION {new.block}
+{ output.state before.all =
+    'skip$
+    { after.block 'output.state := }
+  if$
+}
+
+FUNCTION {new.sentence}
+{ output.state after.block =
+    'skip$
+    { output.state before.all =
+        'skip$
+        { after.sentence 'output.state := }
+      if$
+    }
+  if$
+}
+
+FUNCTION {not}
+{   { #0 }
+    { #1 }
+  if$
+}
+
+FUNCTION {and}
+{   'skip$
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {or}
+{   { pop$ #1 }
+    'skip$
+  if$
+}
+
+FUNCTION {new.block.checka}
+{ empty$
+    'skip$
+    'new.block
+  if$
+}
+
+FUNCTION {new.block.checkb}
+{ empty$
+  swap$ empty$
+  and
+    'skip$
+    'new.block
+  if$
+}
+
+FUNCTION {new.sentence.checka}
+{ empty$
+    'skip$
+    'new.sentence
+  if$
+}
+
+FUNCTION {new.sentence.checkb}
+{ empty$
+  swap$ empty$
+  and
+    'skip$
+    'new.sentence
+  if$
+}
+
+FUNCTION {field.or.null}
+{ duplicate$ empty$
+    { pop$ "" }
+    'skip$
+  if$
+}
+
+FUNCTION {emphasize}
+{ duplicate$ empty$
+    { pop$ "" }
+    { "\emph{" swap$ * "}" * }
+  if$
+}
+
+INTEGERS { nameptr namesleft numnames }
+
+FUNCTION {format.names}
+{ 's :=
+  #1 'nameptr :=
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { s nameptr "{f.~}{vv~}{ll}{, jj}" format.name$ 't :=
+      nameptr #1 >
+        { namesleft #1 >
+            { ", " * t * }
+            { numnames #2 >
+                { "," * }
+                'skip$
+              if$
+              t "others" =
+                { " et~al." * }
+                { " and " * t * }
+              if$
+            }
+          if$
+        }
+        't
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+}
+
+FUNCTION {format.key}
+{ empty$
+    { key field.or.null }
+    { "" }
+  if$
+}
+
+FUNCTION {format.authors}
+{ author empty$
+    { "" }
+    { author format.names }
+  if$
+}
+
+FUNCTION {format.editors}
+{ editor empty$
+    { "" }
+    { editor format.names
+      editor num.names$ #1 >
+        { ", editors" * }
+        { ", editor" * }
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.isbn}
+{ isbn empty$
+    { "" }
+    { new.block "ISBN " isbn * }
+  if$
+}
+
+FUNCTION {format.issn}
+{ issn empty$
+    { "" }
+    { new.block "ISSN " issn * }
+  if$
+}
+
+FUNCTION {format.url}
+{ url empty$
+    { "" }
+    { new.block "URL \url{" url * "}" * }
+  if$
+}
+
+FUNCTION {format.doi}
+{ doi empty$
+    { "" }
+    { new.block "\doi{" doi * "}" * }
+  if$
+}
+
+FUNCTION {format.title}
+{ title empty$
+    { "" }
+    { title "t" change.case$ }
+  if$
+}
+
+FUNCTION {format.full.names}
+{'s :=
+  #1 'nameptr :=
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { s nameptr
+      "{vv~}{ll}" format.name$ 't :=
+      nameptr #1 >
+        {
+          namesleft #1 >
+            { ", " * t * }
+            {
+              numnames #2 >
+                { "," * }
+                'skip$
+              if$
+              t "others" =
+                { " et~al." * }
+                { " and " * t * }
+              if$
+            }
+          if$
+        }
+        't
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+}
+
+FUNCTION {author.editor.full}
+{ author empty$
+    { editor empty$
+        { "" }
+        { editor format.full.names }
+      if$
+    }
+    { author format.full.names }
+  if$
+}
+
+FUNCTION {author.full}
+{ author empty$
+    { "" }
+    { author format.full.names }
+  if$
+}
+
+FUNCTION {editor.full}
+{ editor empty$
+    { "" }
+    { editor format.full.names }
+  if$
+}
+
+FUNCTION {make.full.names}
+{ type$ "book" =
+  type$ "inbook" =
+  or
+    'author.editor.full
+    { type$ "proceedings" =
+        'editor.full
+        'author.full
+      if$
+    }
+  if$
+}
+
+FUNCTION {output.bibitem}
+{ newline$
+  "\bibitem[" write$
+  label write$
+  ")" make.full.names duplicate$ short.list =
+     { pop$ }
+     { * }
+   if$
+  "]{" * write$
+  cite$ write$
+  "}" write$
+  newline$
+  ""
+  before.all 'output.state :=
+}
+
+FUNCTION {n.dashify}
+{ 't :=
+  ""
+    { t empty$ not }
+    { t #1 #1 substring$ "-" =
+        { t #1 #2 substring$ "--" = not
+            { "--" *
+              t #2 global.max$ substring$ 't :=
+            }
+            {   { t #1 #1 substring$ "-" = }
+                { "-" *
+                  t #2 global.max$ substring$ 't :=
+                }
+              while$
+            }
+          if$
+        }
+        { t #1 #1 substring$ *
+          t #2 global.max$ substring$ 't :=
+        }
+      if$
+    }
+  while$
+}
+
+FUNCTION {format.date}
+{ year duplicate$ empty$
+    { "empty year in " cite$ * warning$
+       pop$ "" }
+    'skip$
+  if$
+  month empty$
+    'skip$
+    { month
+      " " * swap$ *
+    }
+  if$
+  extra.label *
+}
+
+FUNCTION {format.btitle}
+{ title emphasize
+}
+
+FUNCTION {tie.or.space.connect}
+{ duplicate$ text.length$ #3 <
+    { "~" }
+    { " " }
+  if$
+  swap$ * *
+}
+
+FUNCTION {either.or.check}
+{ empty$
+    'pop$
+    { "can't use both " swap$ * " fields in " * cite$ * warning$ }
+  if$
+}
+
+FUNCTION {format.bvolume}
+{ volume empty$
+    { "" }
+    { "volume" volume tie.or.space.connect
+      series empty$
+        'skip$
+        { " of " * series emphasize * }
+      if$
+      "volume and number" number either.or.check
+    }
+  if$
+}
+
+FUNCTION {format.number.series}
+{ volume empty$
+    { number empty$
+        { series field.or.null }
+        { output.state mid.sentence =
+            { "number" }
+            { "Number" }
+          if$
+          number tie.or.space.connect
+          series empty$
+            { "there's a number but no series in " cite$ * warning$ }
+            { " in " * series * }
+          if$
+        }
+      if$
+    }
+    { "" }
+  if$
+}
+
+FUNCTION {format.edition}
+{ edition empty$
+    { "" }
+    { output.state mid.sentence =
+        { edition "l" change.case$ " edition" * }
+        { edition "t" change.case$ " edition" * }
+      if$
+    }
+  if$
+}
+
+INTEGERS { multiresult }
+
+FUNCTION {multi.page.check}
+{ 't :=
+  #0 'multiresult :=
+    { multiresult not
+      t empty$ not
+      and
+    }
+    { t #1 #1 substring$
+      duplicate$ "-" =
+      swap$ duplicate$ "," =
+      swap$ "+" =
+      or or
+        { #1 'multiresult := }
+        { t #2 global.max$ substring$ 't := }
+      if$
+    }
+  while$
+  multiresult
+}
+
+FUNCTION {format.pages}
+{ pages empty$
+    { "" }
+    { pages multi.page.check
+        { "pages" pages n.dashify tie.or.space.connect }
+        { "page" pages tie.or.space.connect }
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.eid}
+{ eid empty$
+    { "" }
+    { "art." eid tie.or.space.connect }
+  if$
+}
+
+FUNCTION {format.vol.num.pages}
+{ volume field.or.null
+  number empty$
+    'skip$
+    { "\penalty0 (" number * ")" * *
+      volume empty$
+        { "there's a number but no volume in " cite$ * warning$ }
+        'skip$
+      if$
+    }
+  if$
+  pages empty$
+    'skip$
+    { duplicate$ empty$
+        { pop$ format.pages }
+        { ":\penalty0 " * pages n.dashify * }
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.vol.num.eid}
+{ volume field.or.null
+  number empty$
+    'skip$
+    { "\penalty0 (" number * ")" * *
+      volume empty$
+        { "there's a number but no volume in " cite$ * warning$ }
+        'skip$
+      if$
+    }
+  if$
+  eid empty$
+    'skip$
+    { duplicate$ empty$
+        { pop$ format.eid }
+        { ":\penalty0 " * eid * }
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.chapter.pages}
+{ chapter empty$
+    'format.pages
+    { type empty$
+        { "chapter" }
+        { type "l" change.case$ }
+      if$
+      chapter tie.or.space.connect
+      pages empty$
+        'skip$
+        { ", " * format.pages * }
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.in.ed.booktitle}
+{ booktitle empty$
+    { "" }
+    { editor empty$
+        { "In " booktitle emphasize * }
+        { "In " format.editors * ", " * booktitle emphasize * }
+      if$
+    }
+  if$
+}
+
+FUNCTION {empty.misc.check}
+{ author empty$ title empty$ howpublished empty$
+  month empty$ year empty$ note empty$
+  and and and and and
+  key empty$ not and
+    { "all relevant fields are empty in " cite$ * warning$ }
+    'skip$
+  if$
+}
+
+FUNCTION {format.thesis.type}
+{ type empty$
+    'skip$
+    { pop$
+      type "t" change.case$
+    }
+  if$
+}
+
+FUNCTION {format.tr.number}
+{ type empty$
+    { "Technical Report" }
+    'type
+  if$
+  number empty$
+    { "t" change.case$ }
+    { number tie.or.space.connect }
+  if$
+}
+
+FUNCTION {format.article.crossref}
+{ key empty$
+    { journal empty$
+        { "need key or journal for " cite$ * " to crossref " * crossref *
+          warning$
+          ""
+        }
+        { "In \emph{" journal * "}" * }
+      if$
+    }
+    { "In " }
+  if$
+  " \citet{" * crossref * "}" *
+}
+
+FUNCTION {format.book.crossref}
+{ volume empty$
+    { "empty volume in " cite$ * "'s crossref of " * crossref * warning$
+      "In "
+    }
+    { "Volume" volume tie.or.space.connect
+      " of " *
+    }
+  if$
+  editor empty$
+  editor field.or.null author field.or.null =
+  or
+    { key empty$
+        { series empty$
+            { "need editor, key, or series for " cite$ * " to crossref " *
+              crossref * warning$
+              "" *
+            }
+            { "\emph{" * series * "}" * }
+          if$
+        }
+        'skip$
+      if$
+    }
+    'skip$
+  if$
+  " \citet{" * crossref * "}" *
+}
+
+FUNCTION {format.incoll.inproc.crossref}
+{ editor empty$
+  editor field.or.null author field.or.null =
+  or
+    { key empty$
+        { booktitle empty$
+            { "need editor, key, or booktitle for " cite$ * " to crossref " *
+              crossref * warning$
+              ""
+            }
+            { "In \emph{" booktitle * "}" * }
+          if$
+        }
+        { "In " }
+      if$
+    }
+    { "In " }
+  if$
+  " \citet{" * crossref * "}" *
+}
+
+FUNCTION {article}
+{ output.bibitem
+  format.authors "author" output.check
+  author format.key output
+  new.block
+  format.title "title" output.check
+  new.block
+  crossref missing$
+    { journal emphasize "journal" output.check
+      eid empty$
+        { format.vol.num.pages output }
+        { format.vol.num.eid output }
+      if$
+      format.date "year" output.check
+    }
+    { format.article.crossref output.nonnull
+      eid empty$
+        { format.pages output }
+        { format.eid output }
+      if$
+    }
+  if$
+  format.issn output
+  format.doi output
+  format.url output
+  new.block
+  note output
+  fin.entry
+}
+
+FUNCTION {book}
+{ output.bibitem
+  author empty$
+    { format.editors "author and editor" output.check
+      editor format.key output
+    }
+    { format.authors output.nonnull
+      crossref missing$
+        { "author and editor" editor either.or.check }
+        'skip$
+      if$
+    }
+  if$
+  new.block
+  format.btitle "title" output.check
+  crossref missing$
+    { format.bvolume output
+      new.block
+      format.number.series output
+      new.sentence
+      publisher "publisher" output.check
+      address output
+    }
+    { new.block
+      format.book.crossref output.nonnull
+    }
+  if$
+  format.edition output
+  format.date "year" output.check
+  format.isbn output
+  format.doi output
+  format.url output
+  new.block
+  note output
+  fin.entry
+}
+
+FUNCTION {booklet}
+{ output.bibitem
+  format.authors output
+  author format.key output
+  new.block
+  format.title "title" output.check
+  howpublished address new.block.checkb
+  howpublished output
+  address output
+  format.date output
+  format.isbn output
+  format.doi output
+  format.url output
+  new.block
+  note output
+  fin.entry
+}
+
+FUNCTION {inbook}
+{ output.bibitem
+  author empty$
+    { format.editors "author and editor" output.check
+      editor format.key output
+    }
+    { format.authors output.nonnull
+      crossref missing$
+        { "author and editor" editor either.or.check }
+        'skip$
+      if$
+    }
+  if$
+  new.block
+  format.btitle "title" output.check
+  crossref missing$
+    { format.bvolume output
+      format.chapter.pages "chapter and pages" output.check
+      new.block
+      format.number.series output
+      new.sentence
+      publisher "publisher" output.check
+      address output
+    }
+    { format.chapter.pages "chapter and pages" output.check
+      new.block
+      format.book.crossref output.nonnull
+    }
+  if$
+  format.edition output
+  format.date "year" output.check
+  format.isbn output
+  format.doi output
+  format.url output
+  new.block
+  note output
+  fin.entry
+}
+
+FUNCTION {incollection}
+{ output.bibitem
+  format.authors "author" output.check
+  author format.key output
+  new.block
+  format.title "title" output.check
+  new.block
+  crossref missing$
+    { format.in.ed.booktitle "booktitle" output.check
+      format.bvolume output
+      format.number.series output
+      format.chapter.pages output
+      new.sentence
+      publisher "publisher" output.check
+      address output
+      format.edition output
+      format.date "year" output.check
+    }
+    { format.incoll.inproc.crossref output.nonnull
+      format.chapter.pages output
+    }
+  if$
+  format.isbn output
+  format.doi output
+  format.url output
+  new.block
+  note output
+  fin.entry
+}
+
+FUNCTION {inproceedings}
+{ output.bibitem
+  format.authors "author" output.check
+  author format.key output
+  new.block
+  format.title "title" output.check
+  new.block
+  crossref missing$
+    { format.in.ed.booktitle "booktitle" output.check
+      format.bvolume output
+      format.number.series output
+      format.pages output
+      address empty$
+        { organization publisher new.sentence.checkb
+          organization output
+          publisher output
+          format.date "year" output.check
+        }
+        { address output.nonnull
+          format.date "year" output.check
+          new.sentence
+          organization output
+          publisher output
+        }
+      if$
+    }
+    { format.incoll.inproc.crossref output.nonnull
+      format.pages output
+    }
+  if$
+  format.isbn output
+  format.doi output
+  format.url output
+  new.block
+  note output
+  fin.entry
+}
+
+FUNCTION {conference} { inproceedings }
+
+FUNCTION {manual}
+{ output.bibitem
+  format.authors output
+  author format.key output
+  new.block
+  format.btitle "title" output.check
+  organization address new.block.checkb
+  organization output
+  address output
+  format.edition output
+  format.date output
+  format.url output
+  new.block
+  note output
+  fin.entry
+}
+
+FUNCTION {mastersthesis}
+{ output.bibitem
+  format.authors "author" output.check
+  author format.key output
+  new.block
+  format.title "title" output.check
+  new.block
+  "Master's thesis" format.thesis.type output.nonnull
+  school "school" output.check
+  address output
+  format.date "year" output.check
+  format.url output
+  new.block
+  note output
+  fin.entry
+}
+
+FUNCTION {misc}
+{ output.bibitem
+  format.authors output
+  author format.key output
+  title howpublished new.block.checkb
+  format.title output
+  howpublished new.block.checka
+  howpublished output
+  format.date output
+  format.issn output
+  format.url output
+  new.block
+  note output
+  fin.entry
+  empty.misc.check
+}
+
+FUNCTION {phdthesis}
+{ output.bibitem
+  format.authors "author" output.check
+  author format.key output
+  new.block
+  format.btitle "title" output.check
+  new.block
+  "PhD thesis" format.thesis.type output.nonnull
+  school "school" output.check
+  address output
+  format.date "year" output.check
+  format.url output
+  new.block
+  note output
+  fin.entry
+}
+
+FUNCTION {proceedings}
+{ output.bibitem
+  format.editors output
+  editor format.key output
+  new.block
+  format.btitle "title" output.check
+  format.bvolume output
+  format.number.series output
+  address output
+  format.date "year" output.check
+  new.sentence
+  organization output
+  publisher output
+  format.isbn output
+  format.doi output
+  format.url output
+  new.block
+  note output
+  fin.entry
+}
+
+FUNCTION {techreport}
+{ output.bibitem
+  format.authors "author" output.check
+  author format.key output
+  new.block
+  format.title "title" output.check
+  new.block
+  format.tr.number output.nonnull
+  institution "institution" output.check
+  address output
+  format.date "year" output.check
+  format.url output
+  new.block
+  note output
+  fin.entry
+}
+
+FUNCTION {unpublished}
+{ output.bibitem
+  format.authors "author" output.check
+  author format.key output
+  new.block
+  format.title "title" output.check
+  new.block
+  note "note" output.check
+  format.date output
+  format.url output
+  fin.entry
+}
+
+FUNCTION {default.type} { misc }
+
+
+MACRO {jan} {"January"}
+
+MACRO {feb} {"February"}
+
+MACRO {mar} {"March"}
+
+MACRO {apr} {"April"}
+
+MACRO {may} {"May"}
+
+MACRO {jun} {"June"}
+
+MACRO {jul} {"July"}
+
+MACRO {aug} {"August"}
+
+MACRO {sep} {"September"}
+
+MACRO {oct} {"October"}
+
+MACRO {nov} {"November"}
+
+MACRO {dec} {"December"}
+
+
+
+MACRO {acmcs} {"ACM Computing Surveys"}
+
+MACRO {acta} {"Acta Informatica"}
+
+MACRO {cacm} {"Communications of the ACM"}
+
+MACRO {ibmjrd} {"IBM Journal of Research and Development"}
+
+MACRO {ibmsj} {"IBM Systems Journal"}
+
+MACRO {ieeese} {"IEEE Transactions on Software Engineering"}
+
+MACRO {ieeetc} {"IEEE Transactions on Computers"}
+
+MACRO {ieeetcad}
+ {"IEEE Transactions on Computer-Aided Design of Integrated Circuits"}
+
+MACRO {ipl} {"Information Processing Letters"}
+
+MACRO {jacm} {"Journal of the ACM"}
+
+MACRO {jcss} {"Journal of Computer and System Sciences"}
+
+MACRO {scp} {"Science of Computer Programming"}
+
+MACRO {sicomp} {"SIAM Journal on Computing"}
+
+MACRO {tocs} {"ACM Transactions on Computer Systems"}
+
+MACRO {tods} {"ACM Transactions on Database Systems"}
+
+MACRO {tog} {"ACM Transactions on Graphics"}
+
+MACRO {toms} {"ACM Transactions on Mathematical Software"}
+
+MACRO {toois} {"ACM Transactions on Office Information Systems"}
+
+MACRO {toplas} {"ACM Transactions on Programming Languages and Systems"}
+
+MACRO {tcs} {"Theoretical Computer Science"}
+
+
+READ
+
+FUNCTION {sortify}
+{ purify$
+  "l" change.case$
+}
+
+INTEGERS { len }
+
+FUNCTION {chop.word}
+{ 's :=
+  'len :=
+  s #1 len substring$ =
+    { s len #1 + global.max$ substring$ }
+    's
+  if$
+}
+
+FUNCTION {format.lab.names}
+{ 's :=
+  s #1 "{vv~}{ll}" format.name$
+  s num.names$ duplicate$
+  #2 >
+    { pop$ " et~al." * }
+    { #2 <
+        'skip$
+        { s #2 "{ff }{vv }{ll}{ jj}" format.name$ "others" =
+            { " et~al." * }
+            { " and " * s #2 "{vv~}{ll}" format.name$ * }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {author.key.label}
+{ author empty$
+    { key empty$
+        { cite$ #1 #3 substring$ }
+        'key
+      if$
+    }
+    { author format.lab.names }
+  if$
+}
+
+FUNCTION {author.editor.key.label}
+{ author empty$
+    { editor empty$
+        { key empty$
+            { cite$ #1 #3 substring$ }
+            'key
+          if$
+        }
+        { editor format.lab.names }
+      if$
+    }
+    { author format.lab.names }
+  if$
+}
+
+FUNCTION {author.key.organization.label}
+{ author empty$
+    { key empty$
+        { organization empty$
+            { cite$ #1 #3 substring$ }
+            { "The " #4 organization chop.word #3 text.prefix$ }
+          if$
+        }
+        'key
+      if$
+    }
+    { author format.lab.names }
+  if$
+}
+
+FUNCTION {editor.key.organization.label}
+{ editor empty$
+    { key empty$
+        { organization empty$
+            { cite$ #1 #3 substring$ }
+            { "The " #4 organization chop.word #3 text.prefix$ }
+          if$
+        }
+        'key
+      if$
+    }
+    { editor format.lab.names }
+  if$
+}
+
+FUNCTION {calc.short.authors}
+{ type$ "book" =
+  type$ "inbook" =
+  or
+    'author.editor.key.label
+    { type$ "proceedings" =
+        'editor.key.organization.label
+        { type$ "manual" =
+            'author.key.organization.label
+            'author.key.label
+          if$
+        }
+      if$
+    }
+  if$
+  'short.list :=
+}
+
+FUNCTION {calc.label}
+{ calc.short.authors
+  short.list
+  "("
+  *
+  year duplicate$ empty$
+  short.list key field.or.null = or
+     { pop$ "" }
+     'skip$
+  if$
+  *
+  'label :=
+}
+
+FUNCTION {sort.format.names}
+{ 's :=
+  #1 'nameptr :=
+  ""
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    {
+      s nameptr "{vv{ } }{ll{ }}{  ff{ }}{  jj{ }}" format.name$ 't :=
+      nameptr #1 >
+        {
+          "   "  *
+          namesleft #1 = t "others" = and
+            { "zzzzz" * }
+            { numnames #2 > nameptr #2 = and
+                { "zz" * year field.or.null * "   " * }
+                'skip$
+              if$
+              t sortify *
+            }
+          if$
+        }
+        { t sortify * }
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+}
+
+FUNCTION {sort.format.title}
+{ 't :=
+  "A " #2
+    "An " #3
+      "The " #4 t chop.word
+    chop.word
+  chop.word
+  sortify
+  #1 global.max$ substring$
+}
+
+FUNCTION {author.sort}
+{ author empty$
+    { key empty$
+        { "to sort, need author or key in " cite$ * warning$
+          ""
+        }
+        { key sortify }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+
+FUNCTION {author.editor.sort}
+{ author empty$
+    { editor empty$
+        { key empty$
+            { "to sort, need author, editor, or key in " cite$ * warning$
+              ""
+            }
+            { key sortify }
+          if$
+        }
+        { editor sort.format.names }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+
+FUNCTION {author.organization.sort}
+{ author empty$
+    { organization empty$
+        { key empty$
+            { "to sort, need author, organization, or key in " cite$ * warning$
+              ""
+            }
+            { key sortify }
+          if$
+        }
+        { "The " #4 organization chop.word sortify }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+
+FUNCTION {editor.organization.sort}
+{ editor empty$
+    { organization empty$
+        { key empty$
+            { "to sort, need editor, organization, or key in " cite$ * warning$
+              ""
+            }
+            { key sortify }
+          if$
+        }
+        { "The " #4 organization chop.word sortify }
+      if$
+    }
+    { editor sort.format.names }
+  if$
+}
+
+
+FUNCTION {presort}
+{ calc.label
+  label sortify
+  "    "
+  *
+  type$ "book" =
+  type$ "inbook" =
+  or
+    'author.editor.sort
+    { type$ "proceedings" =
+        'editor.organization.sort
+        { type$ "manual" =
+            'author.organization.sort
+            'author.sort
+          if$
+        }
+      if$
+    }
+  if$
+  "    "
+  *
+  year field.or.null sortify
+  *
+  "    "
+  *
+  cite$
+  *
+  #1 entry.max$ substring$
+  'sort.label :=
+  sort.label *
+  #1 entry.max$ substring$
+  'sort.key$ :=
+}
+
+ITERATE {presort}
+
+SORT
+
+STRINGS { longest.label last.label next.extra }
+
+INTEGERS { longest.label.width last.extra.num number.label }
+
+FUNCTION {initialize.longest.label}
+{ "" 'longest.label :=
+  #0 int.to.chr$ 'last.label :=
+  "" 'next.extra :=
+  #0 'longest.label.width :=
+  #0 'last.extra.num :=
+  #0 'number.label :=
+}
+
+FUNCTION {forward.pass}
+{ last.label label =
+    { last.extra.num #1 + 'last.extra.num :=
+      last.extra.num int.to.chr$ 'extra.label :=
+    }
+    { "a" chr.to.int$ 'last.extra.num :=
+      "" 'extra.label :=
+      label 'last.label :=
+    }
+  if$
+  number.label #1 + 'number.label :=
+}
+
+FUNCTION {reverse.pass}
+{ next.extra "b" =
+    { "a" 'extra.label := }
+    'skip$
+  if$
+  extra.label 'next.extra :=
+  extra.label
+  duplicate$ empty$
+    'skip$
+    { "{\natexlab{" swap$ * "}}" * }
+  if$
+  'extra.label :=
+  label extra.label * 'label :=
+}
+
+EXECUTE {initialize.longest.label}
+
+ITERATE {forward.pass}
+
+REVERSE {reverse.pass}
+
+FUNCTION {bib.sort.order}
+{ sort.label  'sort.key$ :=
+}
+
+ITERATE {bib.sort.order}
+
+SORT
+
+FUNCTION {begin.bib}
+{   preamble$ empty$
+    'skip$
+    { preamble$ write$ newline$ }
+  if$
+  "\begin{thebibliography}{" number.label int.to.str$ * "}" *
+  write$ newline$
+  "\providecommand{\natexlab}[1]{#1}"
+  write$ newline$
+  "\providecommand{\url}[1]{\texttt{#1}}"
+  write$ newline$
+  "\expandafter\ifx\csname urlstyle\endcsname\relax"
+  write$ newline$
+  "  \providecommand{\doi}[1]{doi: #1}\else"
+  write$ newline$
+  "  \providecommand{\doi}{doi: \begingroup \urlstyle{rm}\Url}\fi"
+  write$ newline$
+}
+
+EXECUTE {begin.bib}
+
+EXECUTE {init.state.consts}
+
+ITERATE {call.type$}
+
+FUNCTION {end.bib}
+{ newline$
+  "\end{thebibliography}" write$ newline$
+}
+
+EXECUTE {end.bib}

--- a/sbreview.bib
+++ b/sbreview.bib
@@ -1,7 +1,7 @@
 @article{funkhouser2013mom,
-  title={Mom Knows Best: The Universality of Maternal Microbial Transmission},
+  title={Mom Knows Best: {T}he Universality of Maternal Microbial Transmission},
   author={Funkhouser, Lisa J and Bordenstein, Seth R},
-  journal={PLoS biology},
+  journal={PLOS Biology},
   volume={11},
   number={8},
   pages={e1001631},
@@ -12,7 +12,7 @@
 @article{steel2008maximum,
   title={Maximum likelihood supertrees},
   author={Steel, Mike and Rodrigo, Allen},
-  journal={Systematic biology},
+  journal={Systematic Biology},
   volume={57},
   number={2},
   pages={243--250},
@@ -23,7 +23,7 @@
 @article{la2012statistical,
   title={Statistical Object Data Analysis of Taxonomic Trees from Human Microbiome Data},
   author={La Rosa, Patricio S and Shands, Berkley and Deych, Elena and Zhou, Yanjiao and Sodergren, Erica and Weinstock, George and Shannon, William D},
-  journal={PloS one},
+  journal={PLOS ONE},
   volume={7},
   number={11},
   pages={e48996},
@@ -32,9 +32,9 @@
 }
 
 @article{holmes2012dirichlet,
-  title={Dirichlet multinomial mixtures: generative models for microbial metagenomics},
+  title={Dirichlet multinomial mixtures: {G}enerative models for microbial metagenomics},
   author={Holmes, Ian and Harris, Keith and Quince, Christopher},
-  journal={PLoS One},
+  journal={PLOS ONE},
   volume={7},
   number={2},
   pages={e30126},
@@ -45,7 +45,7 @@
 @article{la2012hypothesis,
   title={Hypothesis Testing and Power Calculations for Taxonomic-Based Human Microbiome Data},
   author={La Rosa, Patricio S and Brooks, J Paul and Deych, Elena and Boone, Edward L and Edwards, David J and Wang, Qin and Sodergren, Erica and Weinstock, George and Shannon, William D},
-  journal={PloS one},
+  journal={PLOS ONE},
   volume={7},
   number={12},
   pages={e52078},
@@ -54,7 +54,7 @@
 }
 
 @article{robinson2010edger,
-  title={edgeR: a Bioconductor package for differential expression analysis of digital gene expression data},
+  title={{edgeR}: a {B}ioconductor package for differential expression analysis of digital gene expression data},
   author={Robinson, Mark D and McCarthy, Davis J and Smyth, Gordon K},
   journal={Bioinformatics},
   volume={26},
@@ -75,7 +75,7 @@
 }
 
 @article{bragg2012fast,
-  title={Fast, accurate error-correction of amplicon pyrosequences using Acacia},
+  title={Fast, accurate error-correction of amplicon pyrosequences using {A}cacia},
   author={Bragg, Lauren and Stone, Glenn and Imelfort, Michael and Hugenholtz, Philip and Tyson, Gene W},
   journal={Nature Methods},
   volume={9},
@@ -99,7 +99,7 @@
 @article{quince2011removing,
   title={Removing noise from pyrosequenced amplicons},
   author={Quince, Christopher and Lanzen, Anders and Davenport, Russell J and Turnbaugh, Peter J},
-  journal={BMC bioinformatics},
+  journal={BMC {B}ioinformatics},
   volume={12},
   number={1},
   pages={38},
@@ -108,7 +108,7 @@
 }
 
 @article{hao2011clustering,
-  title={Clustering 16S rRNA for OTU prediction: a method of unsupervised Bayesian clustering},
+  title={Clustering {16S} {rRNA} for {OTU} prediction: {A} method of unsupervised {B}ayesian clustering},
   author={Hao, Xiaolin and Jiang, Rui and Chen, Ting},
   journal={Bioinformatics},
   volume={27},
@@ -127,7 +127,7 @@
 }
 
 @article{hartmann2006maximizing,
-  title={Maximizing phylogenetic diversity in biodiversity conservation: greedy solutions to the Noah's Ark problem},
+  title={Maximizing phylogenetic diversity in biodiversity conservation: {G}reedy solutions to the {N}oah's {A}rk problem},
   author={Hartmann, Klaas and Steel, Mike},
   journal={Systematic Biology},
   volume={55},
@@ -140,7 +140,7 @@
 @article{pardi2007resource,
   title={Resource-aware taxon selection for maximizing phylogenetic diversity},
   author={Pardi, Fabio and Goldman, Nick},
-  journal={Systematic biology},
+  journal={Systematic Biology},
   volume={56},
   number={3},
   pages={431--444},
@@ -149,9 +149,9 @@
 }
 
 @article{hewitt2013bacterial,
-  title={Bacterial diversity in two neonatal intensive care units (NICUs)},
+  title={Bacterial diversity in two neonatal intensive care units ({NICU}s)},
   author={Hewitt, Krissi M and Mannino, Frank L and Gonzalez, Antonio and Chase, John H and Caporaso, J Gregory and Knight, Rob and Kelley, Scott T},
-  journal={PloS one},
+  journal={PLOS ONE},
   volume={8},
   number={1},
   pages={e54703},
@@ -162,7 +162,7 @@
 @article{lozupone2013meta,
   title={Meta-analyses of studies of the human microbiota},
   author={Lozupone, Catherine and Stombaugh, Jesse and Gonzalez, Antonio and Ackermann, Gail and Wendel, Doug and Vazquez-Baeza, Yoshiki and Jansson, Janet K and Gordon, Jeffrey I and Knight, Rob},
-  journal={advance access, Genome research},
+  journal={advance access, Genome Research},
   year={2013},
   publisher={Cold Spring Harbor Lab}
 }
@@ -170,7 +170,7 @@
 @article{schloss2008evaluating,
   title={Evaluating different approaches that test whether microbial communities have the same structure},
   author={Schloss, Patrick D},
-  journal={The ISME journal},
+  journal={The ISME Journal},
   volume={2},
   number={3},
   pages={265--275},
@@ -212,9 +212,9 @@
 }
 
 @article{pons2006sequence,
-  title={Sequence-based species delimitation for the DNA taxonomy of undescribed insects},
+  title={Sequence-based species delimitation for the {DNA} taxonomy of undescribed insects},
   author={Pons, Joan and Barraclough, Timothy G and Gomez-Zurita, Jesus and Cardoso, Anabela and Duran, Daniel P and Hazell, Steaphan and Kamoun, Sophien and Sumlin, William D and Vogler, Alfried P},
-  journal={Systematic biology},
+  journal={Systematic Biology},
   volume={55},
   number={4},
   pages={595--609},
@@ -223,7 +223,7 @@
 }
 
 @article{yang2010bayesian,
-  title={Bayesian species delimitation using multilocus sequence data},
+  title={{B}ayesian species delimitation using multilocus sequence data},
   author={Yang, Ziheng and Rannala, Bruce},
   journal={Proceedings of the National Academy of Sciences},
   volume={107},
@@ -234,15 +234,15 @@
 }
 
 @article{edgar2013uparse,
-  title={UPARSE: highly accurate OTU sequences from microbial amplicon reads},
+  title={{UPARSE}: {H}ighly accurate {OTU} sequences from microbial amplicon reads},
   author={Edgar, Robert C},
-  journal={Nature methods advance access},
+  journal={advance access, Nature Methods},
   year={2013},
   publisher={Nature Publishing Group}
 }
 
 @article{moran2008convex,
-  title={Convex recolorings of strings and trees: Definitions, hardness results and algorithms},
+  title={Convex recolorings of strings and trees: {D}efinitions, hardness results and algorithms},
   author={Moran, Shlomo and Snir, Sagi},
   journal={Journal of Computer and System Sciences},
   volume={74},
@@ -253,9 +253,9 @@
 }
 
 @article{mande2012classification,
-  title={Classification of metagenomic sequences: methods and challenges},
+  title={Classification of metagenomic sequences: {M}ethods and challenges},
   author={Mande, Sharmila S and Mohammed, Monzoorul Haque and Ghosh, Tarini Shankar},
-  journal={Briefings in bioinformatics},
+  journal={Briefings in Bioinformatics},
   volume={13},
   number={6},
   pages={669--681},
@@ -264,7 +264,7 @@
 }
 
 @article{zhao2013gut,
-  title={The gut microbiota and obesity: from correlation to causality},
+  title={The gut microbiota and obesity: {F}rom correlation to causality},
   author={Zhao, Liping},
   journal={Nature Reviews Microbiology},
   volume={11},
@@ -275,9 +275,9 @@
 }
 
 @article{poutahidis2013microbial,
-  title={Microbial Reprogramming Inhibits Western Diet-Associated Obesity},
-  author={Poutahidis, Theofilos and Kleinewietfeld, Markus and Smillie, Christopher and Levkovich, Tatiana and Perrotta, Alison and Bhela, Siddheshvar and Varian, Bernard J and Ibrahim, Yassin M and Lakritz, Jessica R and Kearney, Sean M and others},
-  journal={PloS one},
+  title={Microbial Reprogramming Inhibits {W}estern Diet-Associated Obesity},
+  author={Poutahidis, Theofilos and Kleinewietfeld, Markus and Smillie, Christopher and Levkovich, Tatiana and Perrotta, Alison and Bhela, Siddheshvar and Varian, Bernard J. and Ibrahim, Yassin M. and Lakritz, Jessica R. and Kearney, Sean M. and Chatzigiagkos, Antonis and Hafler, David A. and Alm, Eric J. and Erdman, Susan E.},
+  journal={PLOS ONE},
   volume={8},
   number={7},
   pages={e68596},
@@ -309,24 +309,24 @@ http://www.nature.com/nrg/journal/v13/n9/full/nrg3226.html
 }
 
 @article{Rogers2013271,
-title = "Interpreting infective microbiota: the importance of an ecological perspective ",
-journal = "Trends in Microbiology ",
-volume = "21",
-number = "6",
-pages = "271 - 276",
-year = "2013",
-note = "",
-issn = "0966-842X",
-doi = "http://dx.doi.org/10.1016/j.tim.2013.03.004",
-url = "http://www.sciencedirect.com/science/article/pii/S0966842X13000577",
-author = "Geraint B. Rogers and Lucas R. Hoffman and Mary P. Carroll and Kenneth D. Bruce",
+title = {Interpreting infective microbiota: {T}he importance of an ecological perspective},
+journal = {Trends in Microbiology},
+volume = {21},
+number = {6},
+pages = {271--276},
+year = {2013},
+note = {},
+issn = {0966-842X},
+doi = {http://dx.doi.org/10.1016/j.tim.2013.03.004},
+url = {http://www.sciencedirect.com/science/article/pii/S0966842X13000577},
+author = {Rogers, Geraint B. and Hoffman, Lucas R. and Carroll, Mary P. and Bruce, Kenneth D.},
 }
 
 
 @article{clark2013matrix,
-  title={Matrix-Assisted Laser Desorption Ionization--Time of Flight Mass Spectrometry: a Fundamental Shift in the Routine Practice of Clinical Microbiology},
+  title={Matrix-Assisted Laser Desorption Ionization--Time of Flight Mass Spectrometry: {A} Fundamental Shift in the Routine Practice of Clinical Microbiology},
   author={Clark, Andrew E and Kaleta, Erin J and Arora, Amit and Wolk, Donna M},
-  journal={Clinical microbiology reviews},
+  journal={Clinical Microbiology Reviews},
   volume={26},
   number={3},
   pages={547--603},
@@ -337,7 +337,7 @@ author = "Geraint B. Rogers and Lucas R. Hoffman and Mary P. Carroll and Kenneth
 @article{costandi2013citizen,
   title={Citizen microbiome},
   author={Costandi, Moheb},
-  journal={Nature biotechnology},
+  journal={Nature Biotechnology},
   volume={31},
   number={2},
   pages={90--90},
@@ -357,7 +357,7 @@ author = "Geraint B. Rogers and Lucas R. Hoffman and Mary P. Carroll and Kenneth
 }
 
 @article{munch2008statistical,
-  title={Statistical assignment of DNA sequences using Bayesian phylogenetics},
+  title={Statistical assignment of {DNA} sequences using {B}ayesian phylogenetics},
   author={Munch, Kasper and Boomsma, Wouter and Huelsenbeck, John P and Willerslev, Eske and Nielsen, Rasmus},
   journal={Systematic Biology},
   volume={57},
@@ -368,7 +368,7 @@ author = "Geraint B. Rogers and Lucas R. Hoffman and Mary P. Carroll and Kenneth
 }
 
 @article{munch2008fast,
-  title={Fast phylogenetic DNA barcoding},
+  title={Fast phylogenetic {DNA} barcoding},
   author={Munch, Kasper and Boomsma, Wouter and Willerslev, Eske and Nielsen, Rasmus},
   journal={Philosophical Transactions of the Royal Society B: Biological Sciences},
   volume={363},
@@ -380,8 +380,8 @@ author = "Geraint B. Rogers and Lucas R. Hoffman and Mary P. Carroll and Kenneth
 
 http://www.pnas.org/content/109/4/1269.short
 @article{stecher2012gut,
-  title={Gut inflammation can boost horizontal gene transfer between pathogenic and commensal Enterobacteriaceae},
-  author={Stecher, B{\"a}rbel and Denzler, R{\'e}my and Maier, Lisa and Bernet, Florian and Sanders, Mandy J and Pickard, Derek J and Barthel, Manja and Westendorf, Astrid M and Krogfelt, Karen A and Walker, Alan W and others},
+  title={Gut inflammation can boost horizontal gene transfer between pathogenic and commensal {E}nterobacteriaceae},
+  author={Stecher, B{\"a}rbel and Denzler, R{\'e}my and Maier, Lisa and Bernet, Florian and Sanders, Mandy J. and Pickard, Derek J. and Barthel, Manja and Westendorf, Astrid M. and Krogfelt, Karen A. and Walker, Alan W. and Ackermann, Martin and Dobrindt, Ulrich and Thomson, Nicholas R. and Hardt, Wolf-Dietrich},
   journal={Proceedings of the National Academy of Sciences},
   volume={109},
   number={4},
@@ -402,7 +402,7 @@ http://www.pnas.org/content/109/4/1269.short
 }
 
 @article{barker2002phylogenetic,
-  title={Phylogenetic diversity: a quantitative framework for measurement of priority and achievement in biodiversity conservation},
+  title={Phylogenetic diversity: {A} quantitative framework for measurement of priority and achievement in biodiversity conservation},
   author={Barker, G.M.},
   journal={Biological Journal of the Linnean Society},
   volume={76},
@@ -413,7 +413,7 @@ http://www.pnas.org/content/109/4/1269.short
 }
 
 @article{rao1982diversity,
-  title={Diversity and dissimilarity coefficients: a unified approach},
+  title={Diversity and dissimilarity coefficients: {A} unified approach},
   author={Rao, C.R.},
   journal={Theoretical Population Biology},
   volume={21},
@@ -425,7 +425,7 @@ http://www.pnas.org/content/109/4/1269.short
 
 @incollection{vellend2011measuring,
   title={Measuring phylogenetic biodiversity},
-  booktitle={Biological Diversity: Frontiers in Measurement and Assessment},
+  booktitle={Biological Diversity: {F}rontiers in Measurement and Assessment},
   author={Vellend, M. and Cornwell, W.K. and Magnuson-Ford, K. and Mooers, A.},
   year={2011},
   editor={Magurran, A.E. and McGill, B.J.},
@@ -462,9 +462,9 @@ year = {1948}
 }
 
 @article{sharpton2011phylotu,
-  title={PhylOTU: a high-throughput procedure quantifies microbial community diversity and resolves novel taxa from metagenomic data},
+  title={{PhylOTU}: {A} high-throughput procedure quantifies microbial community diversity and resolves novel taxa from metagenomic data},
   author={Sharpton, Thomas J and Riesenfeld, Samantha J and Kembel, Steven W and Ladau, Joshua and O'Dwyer, James P and Green, Jessica L and Eisen, Jonathan A and Pollard, Katherine S},
-  journal={PLoS computational biology},
+  journal={PLOS Computational Biology},
   volume={7},
   number={1},
   pages={e1001061},
@@ -473,9 +473,9 @@ year = {1948}
 }
 
 @article{mcdonald2012biological,
-  title={The Biological Observation Matrix (BIOM) format or: how I learned to stop worrying and love the ome-ome},
-  author={McDonald, Daniel and Clemente, Jose C and Kuczynski, Justin and Rideout, Jai Ram and Stombaugh, Jesse and Wendel, Doug and Wilke, Andreas and Huse, Susan and Hufnagle, John and Meyer, Folker and others},
-  journal={GigaScience},
+  title={The Biological Observation Matrix ({BIOM}) format or: {H}ow I learned to stop worrying and love the ome-ome},
+  author={McDonald, Daniel and Clemente, Jose C and Kuczynski, Justin and Rideout, Jai Ram and Stombaugh, Jesse and Wendel, Doug and Wilke, Andreas and Huse, Susan and Hufnagle, John and Meyer, Folker and Knight, Rob and Caporaso, J Gregory},
+  journal={{GigaScience}},
   volume={1},
   number={1},
   pages={7},
@@ -486,7 +486,7 @@ year = {1948}
 @article{caro2012bacterial,
   title={Bacterial species may exist, metagenomics reveal},
   author={Caro-Quintero, Alejandro and Konstantinidis, Konstantinos T},
-  journal={Environmental microbiology},
+  journal={Environmental Microbiology},
   volume={14},
   number={2},
   pages={347--355},
@@ -497,7 +497,7 @@ year = {1948}
 http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 @article{bapteste2009prokaryotic,
   title={Prokaryotic evolution and the tree of life are two different things},
-  author={Bapteste, Eric and O’Malley, Maureen A and Beiko, Robert G and Ereshefsky, Marc and Gogarten, J Peter and Franklin-Hall, Laura and Lapointe, Fran{\c{c}}ois-Joseph and Dupr{\'e}, John and Dagan, Tal and Boucher, Yan and others},
+  author={Bapteste, Eric and O'Malley, Maureen A and Beiko, Robert G and Ereshefsky, Marc and Gogarten, J Peter and Franklin-Hall, Laura and Lapointe, Fran{\c{c}}ois-Joseph and Dupr{\'e}, John and Dagan, Tal and Boucher, Yan and Martin, William},
   journal={Biol Direct},
   volume={4},
   number={1},
@@ -507,13 +507,24 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 }
 
 @article{huson2011integrative,
-  title={Integrative analysis of environmental sequences using MEGAN4},
+  title={Integrative analysis of environmental sequences using {MEGAN4}},
   author={Huson, Daniel H and Mitra, Suparna and Ruscheweyh, Hans-Joachim and Weber, Nico and Schuster, Stephan C},
-  journal={Genome research},
+  journal={Genome Research},
   volume={21},
   number={9},
   pages={1552--1560},
   year={2011},
+  publisher={Cold Spring Harbor Lab}
+}
+
+@article{huson2007megan,
+  title={MEGAN analysis of metagenomic data},
+  author={Huson, Daniel H and Auch, Alexander F and Qi, Ji and Schuster, Stephan C},
+  journal={Genome research},
+  volume={17},
+  number={3},
+  pages={377--386},
+  year={2007},
   publisher={Cold Spring Harbor Lab}
 }
 
@@ -540,9 +551,9 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 }
 
 @article{dehal2010microbesonline,
-  title={MicrobesOnline: an integrated portal for comparative and functional genomics},
-  author={Dehal, Paramvir S and Joachimiak, Marcin P and Price, Morgan N and Bates, John T and Baumohl, Jason K and Chivian, Dylan and Friedland, Greg D and Huang, Katherine H and Keller, Keith and Novichkov, Pavel S and others},
-  journal={Nucleic acids research},
+  title={{MicrobesOnline}: {A}n integrated portal for comparative and functional genomics},
+  author={Dehal, Paramvir S. and Joachimiak, Marcin P. and Price, Morgan N. and Bates, John T. and Baumohl, Jason K. and Chivian, Dylan and Friedland, Greg D. and Huang, Katherine H. and Keller, Keith and Novichkov, Pavel S. and Dubchak, Inna L. and Alm, Eric J. and Arkin, Adam P.},
+  journal={Nucleic Acids Research},
   volume={38},
   number={suppl 1},
   pages={D396--D400},
@@ -551,7 +562,7 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 }
 
 @article{desantis2006nast,
-  title={NAST: a multiple sequence alignment server for comparative analysis of 16S rRNA genes},
+  title={{NAST}: {A} multiple sequence alignment server for comparative analysis of {16S} {rRNA} genes},
   author={DeSantis, TZ and Hugenholtz, Philip and Keller, K and Brodie, EL and Larsen, N and Piceno, YM and Phan, R and Andersen, Gary L},
   journal={Nucleic Acids Research},
   volume={34},
@@ -562,7 +573,7 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 }
 
 @article{caporaso2010pynast,
-  title={PyNAST: a flexible tool for aligning sequences to a template alignment},
+  title={{PyNAST}: {A} flexible tool for aligning sequences to a template alignment},
   author={Caporaso, J Gregory and Bittinger, Kyle and Bushman, Frederic D and DeSantis, Todd Z and Andersen, Gary L and Knight, Rob},
   journal={Bioinformatics},
   volume={26},
@@ -574,7 +585,7 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 
 @article{yatsunenko2012human,
   title={Human gut microbiome viewed across age and geography},
-  author={Yatsunenko, Tanya and Rey, Federico E and Manary, Mark J and Trehan, Indi and Dominguez-Bello, Maria Gloria and Contreras, Monica and Magris, Magda and Hidalgo, Glida and Baldassano, Robert N and Anokhin, Andrey P and others},
+  author={Yatsunenko, Tanya and Rey, Federico E. and Manary, Mark J. and Trehan, Indi and Dominguez-Bello, Maria Gloria and Contreras, Monica and Magris, Magda and Hidalgo, Glida and Baldassano, Robert N. and Anokhin, Andrey P. and Heath, Andrew C. and Warner, Barbara and Reeder, Jens and Kuczynski, Justin and Caporaso, J. Gregory and Lozupone, Catherine A. and Lauber, Christian and Clemente, Jose Carlos and Knights, Dan and Knight, Rob andGordon, Jeffrey I.},
   journal={Nature},
   volume={486},
   number={7402},
@@ -593,7 +604,7 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 @article{aldous2011five,
   title={Five statistical questions about the tree of life},
   author={Aldous, David J and Krikun, Maxim A and Popovic, Lea},
-  journal={Systematic biology},
+  journal={Systematic Biology},
   volume={60},
   number={3},
   pages={318--328},
@@ -611,7 +622,7 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 }
 
 @article{edgar2011uchime,
-  title={UCHIME improves sensitivity and speed of chimera detection},
+  title={{UCHIME} improves sensitivity and speed of chimera detection},
   author={Edgar, Robert C and Haas, Brian J and Clemente, Jose C and Quince, Christopher and Knight, Rob},
   journal={Bioinformatics},
   volume={27},
@@ -622,7 +633,7 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 }
 
 @article{ashelford2006new,
-  title={New screening software shows that most recent large 16S rRNA gene clone libraries contain chimeras},
+  title={New screening software shows that most recent large {16S} {rRNA} gene clone libraries contain chimeras},
   author={Ashelford, Kevin E and Chuzhanova, Nadia A and Fry, John C and Jones, Antonia J and Weightman, Andrew J},
   journal={Applied and Environmental Microbiology},
   volume={72},
@@ -653,7 +664,7 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 @article{szollHosi2013lateral,
   title={Lateral Gene Transfer from the Dead},
   author={Sz{\"o}ll{\H{o}}si, Gergely J and Tannier, Eric and Lartillot, Nicolas and Daubin, Vincent},
-  journal={Systematic biology},
+  journal={Systematic Biology},
   volume={62},
   number={3},
   pages={386--397},
@@ -662,7 +673,7 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 }
 
 @phdthesis{nawrocki2009structural,
-  title={Structural RNA homology search and alignment using covariance models},
+  title={Structural {RNA} homology search and alignment using covariance models},
   author={Nawrocki, Eric Paul},
   year={2009},
   school={Washington University},
@@ -671,9 +682,9 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 
 
 @article{yarza2008all,
-  title={The All-Species Living Tree project: A 16S rRNA-based phylogenetic tree of all sequenced type strains},
+  title={The {A}ll-{S}pecies {L}iving {T}ree project: {A} {16S} {rRNA}-based phylogenetic tree of all sequenced type strains},
   author={Yarza, Pablo and Richter, Michael and Peplies, J{\"o}rg and Euzeby, Jean and Amann, Rudolf and Schleifer, Karl-Heinz and Ludwig, Wolfgang and Gl{\"o}ckner, Frank Oliver and Rossell{\'o}-M{\'o}ra, Ramon},
-  journal={Systematic and applied microbiology},
+  journal={Systematic and Applied Microbiology},
   volume={31},
   number={4},
   pages={241--250},
@@ -682,9 +693,9 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 }
 
 @article{peplies2008standard,
-  title={A standard operating procedure for phylogenetic inference (SOPPI) using (rRNA) marker genes},
+  title={A standard operating procedure for phylogenetic inference ({SOPPI}) using ({rRNA}) marker genes},
   author={Peplies, J{\"o}rg and Kottmann, Renzo and Ludwig, Wolfgang and Gl{\"o}ckner, Frank Oliver},
-  journal={Systematic and applied microbiology},
+  journal={Systematic and Applied Microbiology},
   volume={31},
   number={4},
   pages={251--257},
@@ -694,7 +705,7 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 
 @article{ley2008evolution,
   title={Evolution of mammals and their gut microbes},
-  author={Ley, Ruth E and Hamady, Micah and Lozupone, Catherine and Turnbaugh, Peter J and Ramey, Rob Roy and Bircher, J Stephen and Schlegel, Michael L and Tucker, Tammy A and Schrenzel, Mark D and Knight, Rob and others},
+  author={Ley, Ruth E. and Hamady, Micah and Lozupone, Catherine and Turnbaugh, Peter J. and Ramey, Rob Roy and Bircher, J. Stephen and Schlegel, Michael L. and Tucker, Tammy A. and Schrenzel, Mark D. and Knight, Rob and Gordon, Jeffrey I.},
   journal={Science},
   volume={320},
   number={5883},
@@ -704,7 +715,7 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 }
 
 @article{blaser2011antibiotic,
-  title={Antibiotic overuse: Stop the killing of beneficial bacteria},
+  title={Antibiotic overuse: {S}top the killing of beneficial bacteria},
   author={Blaser, Martin},
   journal={Nature},
   volume={476},
@@ -715,7 +726,7 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 }
 
 @article{cho2012human,
-  title={The human microbiome: at the interface of health and disease},
+  title={The human microbiome: {A}t the interface of health and disease},
   author={Cho, Ilseung and Blaser, Martin J},
   journal={Nature Reviews Genetics},
   volume={13},
@@ -725,10 +736,21 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
   publisher={Nature Publishing Group}
 }
 
+@article{brady2009phymm,
+  title={Phymm and PhymmBL: metagenomic phylogenetic classification with interpolated Markov models},
+  author={Brady, Arthur and Salzberg, Steven L},
+  journal={Nature methods},
+  volume={6},
+  number={9},
+  pages={673--676},
+  year={2009},
+  publisher={Nature Publishing Group}
+}
+
 @article{peplies2008standard,
-  title={A standard operating procedure for phylogenetic inference (SOPPI) using (rRNA) marker genes},
+  title={A standard operating procedure for phylogenetic inference ({SOPPI}) using ({rRNA}) marker genes},
   author={Peplies, J{\"o}rg and Kottmann, Renzo and Ludwig, Wolfgang and Gl{\"o}ckner, Frank Oliver},
-  journal={Systematic and applied microbiology},
+  journal={Systematic and Applied Microbiology},
   volume={31},
   number={4},
   pages={251--257},
@@ -738,7 +760,7 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 
 % http://bioinformatics.oxfordjournals.org/content/28/14/1823.long
 @article{pruesse2012sina,
-  title={SINA: accurate high-throughput multiple sequence alignment of ribosomal RNA genes},
+  title={{SINA}: {A}ccurate high-throughput multiple sequence alignment of ribosomal {RNA} genes},
   author={Pruesse, Elmar and Peplies, J{\"o}rg and Gl{\"o}ckner, Frank Oliver},
   journal={Bioinformatics},
   volume={28},
@@ -750,9 +772,9 @@ http://www.biomedcentral.com/content/pdf/1745-6150-4-34.pdf
 
 http://nar.oxfordjournals.org/content/41/D1/D590
 @article{quast2013silva,
-  title={The SILVA ribosomal RNA gene database project: improved data processing and web-based tools},
+  title={The {SILVA} ribosomal {RNA} gene database project: {I}mproved data processing and web-based tools},
   author={Quast, Christian and Pruesse, Elmar and Yilmaz, Pelin and Gerken, Jan and Schweer, Timmy and Yarza, Pablo and Peplies, J{\"o}rg and Gl{\"o}ckner, Frank Oliver},
-  journal={Nucleic acids research},
+  journal={Nucleic Acids Research},
   volume={41},
   number={D1},
   pages={D590--D596},
@@ -761,9 +783,9 @@ http://nar.oxfordjournals.org/content/41/D1/D590
 }
 
 @article{pruesse2007silva,
-  title={SILVA: a comprehensive online resource for quality checked and aligned ribosomal RNA sequence data compatible with ARB},
+  title={{SILVA}: {A} comprehensive online resource for quality checked and aligned ribosomal {RNA} sequence data compatible with {ARB}},
   author={Pruesse, Elmar and Quast, Christian and Knittel, Katrin and Fuchs, Bernhard M and Ludwig, Wolfgang and Peplies, J{\"o}rg and Gl{\"o}ckner, Frank Oliver},
-  journal={Nucleic acids research},
+  journal={Nucleic Acids Research},
   volume={35},
   number={21},
   pages={7188--7196},
@@ -773,8 +795,8 @@ http://nar.oxfordjournals.org/content/41/D1/D590
 
 @article{fodor2012most,
   title={The “most wanted” taxa from the human microbiome for whole genome sequencing},
-  author={Fodor, Anthony A and DeSantis, Todd Z and Wylie, Kristine M and Badger, Jonathan H and Ye, Yuzhen and Hepburn, Theresa and Hu, Ping and Sodergren, Erica and Liolios, Konstantinos and Huot-Creasy, Heather and others},
-  journal={PloS one},
+  author={Fodor, Anthony A. and DeSantis, Todd Z. and Wylie, Kristine M. and Badger, Jonathan H. and Ye, Yuzhen and Hepburn, Theresa and Hu, Ping and Sodergren, Erica and Liolios, Konstantinos and Huot-Creasy, Heather and Birren, Bruce W. and Earl, Ashlee M.},
+  journal={PLOS ONE},
   volume={7},
   number={7},
   pages={e41294},
@@ -796,8 +818,8 @@ http://nar.oxfordjournals.org/content/41/D1/D590
 http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0051146
 @article{tito2012insights,
   title={Insights from characterizing extinct human gut microbiomes},
-  author={Tito, Raul Y and Knights, Dan and Metcalf, Jessica and Obregon-Tito, Alexandra J and Cleeland, Lauren and Najar, Fares and Roe, Bruce and Reinhard, Karl and Sobolik, Kristin and Belknap, Samuel and others},
-  journal={PloS one},
+  author={Tito, Raul Y. and Knights, Dan and Metcalf, Jessica and Obregon-Tito, Alexandra J. and Cleeland, Lauren and Najar, Fares and Roe, Bruce and Reinhard, Karl and Sobolik, Kristin and Belknap, Samuel and Foster, Morris and Spicer, Paul and Knight, Rob and Lewis, Jr, Cecil M.},
+  journal={PLOS ONE},
   volume={7},
   number={12},
   pages={e51146},
@@ -807,8 +829,8 @@ http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0051146
 
 http://www.sciencemag.org/content/339/6119/548.short
 @article{smith2013gut,
-  title={Gut microbiomes of Malawian twin pairs discordant for kwashiorkor},
-  author={Smith, Michelle I and Yatsunenko, Tanya and Manary, Mark J and Trehan, Indi and Mkakosya, Rajhab and Cheng, Jiye and Kau, Andrew L and Rich, Stephen S and Concannon, Patrick and Mychaleckyj, Josyf C and others},
+  title={Gut microbiomes of {M}alawian twin pairs discordant for kwashiorkor},
+  author={Smith, Michelle I. and Yatsunenko, Tanya and Manary, Mark J. and Trehan, Indi and Mkakosya, Rajhab and Cheng, Jiye and Kau, Andrew L. and Rich, Stephen S. and Concannon, Patrick and Mychaleckyj, Josyf C. and Liu, Jie and Houpt, Eric and Li, Jia V. and Holmes, Elaine and Nicholson, Jeremy and Knights, Dan and Ursell, Luke K. and Knight, Rob and Gordon, Jeffrey I.},
   journal={Science},
   volume={339},
   number={6119},
@@ -821,7 +843,7 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 @article{ochman2010evolutionary,
   title={Evolutionary relationships of wild hominids recapitulated by gut microbial communities},
   author={Ochman, Howard and Worobey, Michael and Kuo, Chih-Horng and Ndjango, Jean-Bosco N and Peeters, Martine and Hahn, Beatrice H and Hugenholtz, Philip},
-  journal={PLoS biology},
+  journal={PLOS Biology},
   volume={8},
   number={11},
   pages={e1000546},
@@ -832,16 +854,27 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 @article{rosen2008metagenome,
   title={Metagenome Fragment Classification Using N-Mer Frequency Profiles},
   author={Rosen, Gail and Garbarine, Elaine and Caseiro, Diamantino and Polikar, Robi and Sokhansanj, Bahrad},
-  journal={Advances in bioinformatics},
+  journal={Advances in Bioinformatics},
   volume={2008},
   year={2008},
   publisher={Hindawi Publishing Corporation}
 }
 
+@article{liu2008accurate,
+  title={Accurate taxonomy assignments from 16S rRNA sequences produced by highly parallel pyrosequencers},
+  author={Liu, Zongzhi and DeSantis, Todd Z and Andersen, Gary L and Knight, Rob},
+  journal={Nucleic acids research},
+  volume={36},
+  number={18},
+  pages={e120--e120},
+  year={2008},
+  publisher={Oxford Univ Press}
+}
+
 @article{abubucker2012metabolic,
   title={Metabolic reconstruction for metagenomic data and its application to the human microbiome},
   author={Abubucker, Sahar and Segata, Nicola and Goll, Johannes and Schubert, Alyxandria M and Izard, Jacques and Cantarel, Brandi L and Rodriguez-Mueller, Beltran and Zucker, Jeremy and Thiagarajan, Mathangi and Henrissat, Bernard and Owen White and Scott T. Kelley and Barbara Methé and Patrick D. Schloss and Dirk Gevers and Makedonka Mitreva and Curtis Huttenhower},
-  journal={PLoS computational biology},
+  journal={PLOS Computational Biology},
   volume={8},
   number={6},
   pages={e1002358},
@@ -868,7 +901,7 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{pell2012scaling,
-  title={Scaling metagenome sequence assembly with probabilistic de Bruijn graphs},
+  title={Scaling metagenome sequence assembly with probabilistic de {B}ruijn graphs},
   author={Pell, Jason and Hintze, Arend and Canino-Koning, Rosangela and Howe, Adina and Tiedje, James M and Brown, C Titus},
   journal={Proceedings of the National Academy of Sciences},
   volume={109},
@@ -879,7 +912,7 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{baker2010enigmatic,
-  title={Enigmatic, ultrasmall, uncultivated Archaea},
+  title={Enigmatic, ultrasmall, uncultivated {A}rchaea},
   author={Baker, Brett J and Comolli, Luis R and Dick, Gregory J and Hauser, Loren J and Hyatt, Doug and Dill, Brian D and Land, Miriam L and VerBerkmoes, Nathan C and Hettich, Robert L and Banfield, Jillian F},
   journal={Proceedings of the National Academy of Sciences},
   volume={107},
@@ -890,7 +923,7 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{iverson2012untangling,
-  title={Untangling genomes from metagenomes: revealing an uncultured class of marine Euryarchaeota},
+  title={Untangling genomes from metagenomes: {R}evealing an uncultured class of marine {E}uryarchaeota},
   author={Iverson, Vaughn and Morris, Robert M and Frazar, Christian D and Berthiaume, Chris T and Morales, Rhonda L and Armbrust, E Virginia},
   journal={Science},
   volume={335},
@@ -911,7 +944,7 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 @article{podell2013assembly,
   title={Assembly-driven community genomics of a hypersaline microbial ecosystem},
   author={Podell, Sheila and Ugalde, Juan A and Narasingarao, Priya and Banfield, Jillian F and Heidelberg, Karla B and Allen, Eric E},
-  journal={PloS one},
+  journal={PLOS ONE},
   volume={8},
   number={4},
   pages={e61692},
@@ -922,7 +955,7 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 @article{kalisky2011single,
   title={Single-cell genomics},
   author={Kalisky, Tomer and Quake, Stephen R},
-  journal={Nature methods},
+  journal={Nature Methods},
   volume={8},
   number={4},
   pages={311--314},
@@ -931,8 +964,8 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{koser2012rapid,
-  title={Rapid whole-genome sequencing for investigation of a neonatal MRSA outbreak},
-  author={K{\"o}ser, Claudio U and Holden, Matthew TG and Ellington, Matthew J and Cartwright, Edward JP and Brown, Nicholas M and Ogilvy-Stuart, Amanda L and Hsu, Li Yang and Chewapreecha, Claire and Croucher, Nicholas J and Harris, Simon R and others},
+  title={Rapid whole-genome sequencing for investigation of a neonatal {MRSA} outbreak},
+  author={K{\"o}ser, Claudio U. and Holden, Matthew T.G. and Ellington, Matthew J. and Cartwright, Edward J.P. and Brown, Nicholas M. and Ogilvy-Stuart, Amanda L. and Hsu, Li Yang and Chewapreecha, Claire and Croucher, Nicholas J. and Harris, Simon R. and Sanders, Mandy and Enright, Mark C. and Dougan, Gordon and Bentley, Stephen D. and Parkhill, Julian and Fraser, Louise J. and Betley, Jason R. and Schulz-Trieglaff, Ole B. and Smith, Geoffrey P. and Peacock, Sharon J.},
   journal={New England Journal of Medicine},
   volume={366},
   number={24},
@@ -942,7 +975,7 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{klappenbach2000rrna,
-  title={rRNA operon copy number reflects ecological strategies of bacteria},
+  title={{rRNA} operon copy number reflects ecological strategies of bacteria},
   author={Klappenbach, Joel A and Dunbar, John M and Schmidt, Thomas M},
   journal={Applied and Environmental Microbiology},
   volume={66},
@@ -962,9 +995,9 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{klappenbach2001rrndb,
-  title={rrndb: the ribosomal RNA operon copy number database},
+  title={{rrndb}: {T}he ribosomal {RNA} operon copy number database},
   author={Klappenbach, Joel A and Saxman, Paul R and Cole, James R and Schmidt, Thomas M},
-  journal={Nucleic acids research},
+  journal={Nucleic Acids Research},
   volume={29},
   number={1},
   pages={181--184},
@@ -973,7 +1006,7 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{ashelford2005least,
-  title={At least 1 in 20 16S rRNA sequence records currently held in public repositories is estimated to contain substantial anomalies},
+  title={At least 1 in 20 {16S} {rRNA} sequence records currently held in public repositories is estimated to contain substantial anomalies},
   author={Ashelford, Kevin E and Chuzhanova, Nadia A and Fry, John C and Jones, Antonia J and Weightman, Andrew J},
   journal={Applied and Environmental Microbiology},
   volume={71},
@@ -984,7 +1017,7 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{hugenholtz2003chimeric,
-  title={Chimeric 16S rDNA sequences of diverse origin are accumulating in the public databases},
+  title={Chimeric {16S} {rDNA} sequences of diverse origin are accumulating in the public databases},
   author={Hugenholtz, Philip and Huber, Thomas},
   journal={International Journal of Systematic and Evolutionary Microbiology},
   volume={53},
@@ -995,9 +1028,9 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{haas2011chimeric,
-  title={Chimeric 16S rRNA sequence formation and detection in Sanger and 454-pyrosequenced PCR amplicons},
-  author={Haas, Brian J and Gevers, Dirk and Earl, Ashlee M and Feldgarden, Mike and Ward, Doyle V and Giannoukos, Georgia and Ciulla, Dawn and Tabbaa, Diana and Highlander, Sarah K and Sodergren, Erica and others},
-  journal={Genome research},
+  title={Chimeric {16S} {rRNA} sequence formation and detection in {S}anger and 454-pyrosequenced {PCR} amplicons},
+  author={Haas, Brian J. and Gevers, Dirk and Earl, Ashlee M. and Feldgarden, Mike and Ward, Doyle V. and Giannoukos, Georgia and Ciulla, Dawn and Tabbaa, Diana and Highlander, Sarah K. and Sodergren, Erica and Meth{\'e}, Barbara and DeSantis, Todd Z. and The Human Microbiome Consortium and Petrosino, Joseph F. and Knight, Rob and Birren, Bruce W.},
+  journal={Genome Research},
   volume={21},
   number={3},
   pages={494--504},
@@ -1006,9 +1039,9 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{schloss2011reducing,
-  title={Reducing the effects of PCR amplification and sequencing artifacts on 16S rRNA-based studies},
+  title={Reducing the effects of {PCR} amplification and sequencing artifacts on {16S} {rRNA}-based studies},
   author={Schloss, Patrick D and Gevers, Dirk and Westcott, Sarah L},
-  journal={PLOS one},
+  journal={PLOS ONE},
   volume={6},
   number={12},
   pages={e27310},
@@ -1017,7 +1050,7 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{polz1998bias,
-  title={Bias in template-to-product ratios in multitemplate PCR},
+  title={Bias in template-to-product ratios in multitemplate {PCR}},
   author={Polz, Martin F and Cavanaugh, Colleen M},
   journal={Applied and Environmental Microbiology},
   volume={64},
@@ -1028,9 +1061,9 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{suzuki1996bias,
-  title={Bias caused by template annealing in the amplification of mixtures of 16S rRNA genes by PCR.},
+  title={Bias caused by template annealing in the amplification of mixtures of {16S} {rRNA} genes by {PCR}.},
   author={Suzuki, Marcelino T and Giovannoni, Stephen J},
-  journal={Applied and environmental microbiology},
+  journal={Applied and Environmental Microbiology},
   volume={62},
   number={2},
   pages={625--630},
@@ -1039,9 +1072,9 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{degnan2011illumina,
-  title={Illumina-based analysis of microbial community diversity},
+  title={{I}llumina-based analysis of microbial community diversity},
   author={Degnan, Patrick H and Ochman, Howard},
-  journal={The ISME journal},
+  journal={The ISME Journal},
   volume={6},
   number={1},
   pages={183--194},
@@ -1050,9 +1083,9 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{caporaso2012ultra,
-  title={Ultra-high-throughput microbial community analysis on the Illumina HiSeq and MiSeq platforms},
+  title={Ultra-high-throughput microbial community analysis on the {I}llumina {HiSeq} and {MiSeq} platforms},
   author={Caporaso, J Gregory and Lauber, Christian L and Walters, William A and Berg-Lyons, Donna and Huntley, James and Fierer, Noah and Owens, Sarah M and Betley, Jason and Fraser, Louise and Bauer, Markus and Niall Gormley and Jack A Gilbert and Geoff Smith and Rob Knight},
-  journal={The ISME journal},
+  journal={The ISME Journal},
   volume={6},
   number={8},
   pages={1621--1624},
@@ -1061,7 +1094,7 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{fox1977comparative,
-  title={Comparative cataloging of 16S ribosomal ribonucleic acid: molecular approach to procaryotic systematics},
+  title={Comparative cataloging of {16S} ribosomal ribonucleic acid: {M}olecular approach to procaryotic systematics},
   author={Fox, George E and Pechman, Kenneth R and Woese, Carl R},
   journal={International Journal of Systematic Bacteriology},
   volume={27},
@@ -1072,7 +1105,7 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{lane1985rapid,
-  title={Rapid determination of 16S ribosomal RNA sequences for phylogenetic analyses},
+  title={Rapid determination of {16S} ribosomal {RNA} sequences for phylogenetic analyses},
   author={Lane, David J and Pace, Bernadette and Olsen, Gary J and Stahl, David A and Sogin, Mitchell L and Pace, Norman R},
   journal={Proceedings of the National Academy of Sciences},
   volume={82},
@@ -1083,7 +1116,7 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 }
 
 @article{woese1977phylogenetic,
-  title={Phylogenetic structure of the prokaryotic domain: the primary kingdoms},
+  title={Phylogenetic structure of the prokaryotic domain: {T}he primary kingdoms},
   author={Woese, Carl R and Fox, George E},
   journal={Proceedings of the National Academy of Sciences},
   volume={74},
@@ -1096,7 +1129,7 @@ http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1000546
 @article{li2009human,
   title={Human gut bacterial communities are altered by addition of cruciferous vegetables to a controlled fruit-and vegetable-free diet},
   author={Li, Fei and Hullar, Meredith AJ and Schwarz, Yvonne and Lampe, Johanna W},
-  journal={The Journal of nutrition},
+  journal={The Journal of Nutrition},
   volume={139},
   number={9},
   pages={1685--1691},
@@ -1118,7 +1151,7 @@ http://www.sciencedirect.com/science/article/pii/S0092867412014286
 
 http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0066019
 @article{hoffmann2013archaea,
-  title={Archaea and Fungi of the Human Gut Microbiome: Correlations with Diet and Bacterial Residents},
+  title={{A}rchaea and {F}ungi of the Human Gut Microbiome: {C}orrelations with Diet and Bacterial Residents},
   author={Hoffmann, Christian and Dollive, Serena and Grunberg, Stephanie and Chen, Jun and Li, Hongzhe and Wu, Gary D and Lewis, James D and Bushman, Frederic D},
   journal={PLOS ONE},
   volume={8},
@@ -1151,9 +1184,9 @@ http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0066019
 }
 
 @article{minot2011human,
-  title={The human gut virome: inter-individual variation and dynamic response to diet},
+  title={The human gut virome: {I}nter-individual variation and dynamic response to diet},
   author={Minot, Samuel and Sinha, Rohini and Chen, Jun and Li, Hongzhe and Keilbaugh, Sue A and Wu, Gary D and Lewis, James D and Bushman, Frederic D},
-  journal={Genome research},
+  journal={Genome Research},
   volume={21},
   number={10},
   pages={1616--1625},
@@ -1162,9 +1195,9 @@ http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0066019
 }
 
 @article{snitkin2012tracking,
-  title={Tracking a hospital outbreak of carbapenem-resistant Klebsiella pneumoniae with whole-genome sequencing},
+  title={Tracking a hospital outbreak of carbapenem-resistant {K}lebsiella pneumoniae with whole-genome sequencing},
   author={Snitkin, Evan S and Zelazny, Adrian M and Thomas, Pamela J and Stock, Frida and Henderson, David K and Palmore, Tara N and Segre, Julia A},
-  journal={Science translational medicine},
+  journal={Science Translational Medicine},
   volume={4},
   number={148},
   pages={148ra116--148ra116},
@@ -1173,9 +1206,9 @@ http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0066019
 }
 
 @article{evans2006relaxed,
-  title={Relaxed neighbor joining: a fast distance-based phylogenetic tree construction method},
+  title={Relaxed neighbor joining: {A} fast distance-based phylogenetic tree construction method},
   author={Evans, Jason and Sheneman, Luke and Foster, James},
-  journal={Journal of molecular evolution},
+  journal={Journal of Molecular Evolution},
   volume={62},
   number={6},
   pages={785--792},
@@ -1183,7 +1216,7 @@ http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0066019
   publisher={Springer}
 }
 @article{sheneman2006clearcut,
-  title={Clearcut: a fast implementation of relaxed neighbor joining},
+  title={{C}learcut: {A} fast implementation of relaxed neighbor joining},
   author={Sheneman, Luke and Evans, Jason and Foster, James A},
   journal={Bioinformatics},
   volume={22},
@@ -1195,9 +1228,9 @@ http://www.plosone.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.0066019
 
 http://www.mdpi.com/1422-0067/10/11/4723/pdf
 @article{faith2009cladistic,
-  title={The cladistic basis for the phylogenetic diversity (PD) measure links evolutionary features to environmental gradients and supports broad applications of microbial ecology’s ``Phylogenetic Beta Diversity'' framework},
+  title={The cladistic basis for the phylogenetic diversity ({PD}) measure links evolutionary features to environmental gradients and supports broad applications of microbial ecology’s ``{P}hylogenetic {B}eta {D}iversity'' framework},
   author={Faith, Daniel P and Lozupone, Catherine A and Nipperess, David and Knight, Rob},
-  journal={International journal of molecular sciences},
+  journal={International Journal of Molecular Sciences},
   volume={10},
   number={11},
   pages={4723--4741},
@@ -1208,7 +1241,7 @@ http://www.mdpi.com/1422-0067/10/11/4723/pdf
 @article{kembel2011phylogenetic,
   title={The phylogenetic diversity of metagenomes},
   author={Kembel, Steven W and Eisen, Jonathan A and Pollard, Katherine S and Green, Jessica L},
-  journal={PloS one},
+  journal={PLOS ONE},
   volume={6},
   number={8},
   pages={e23214},
@@ -1238,7 +1271,7 @@ http://www.mdpi.com/1422-0067/10/11/4723/pdf
 }
 
 @article{paradis2004ape,
-  title={APE: analyses of phylogenetics and evolution in R language},
+  title={{APE}: {A}nalyses of phylogenetics and evolution in {R} language},
   author={Paradis, Emmanuel and Claude, Julien and Strimmer, Korbinian},
   journal={Bioinformatics},
   volume={20},
@@ -1249,7 +1282,7 @@ http://www.mdpi.com/1422-0067/10/11/4723/pdf
 }
 
 @article{pagel1994detecting,
-  title={Detecting correlated evolution on phylogenies: a general method for the comparative analysis of discrete characters},
+  title={Detecting correlated evolution on phylogenies: {A} general method for the comparative analysis of discrete characters},
   author={Pagel, Mark},
   journal={Proceedings of the Royal Society of London. Series B: Biological Sciences},
   volume={255},
@@ -1260,9 +1293,9 @@ http://www.mdpi.com/1422-0067/10/11/4723/pdf
 }
 
 @article{langille2013predictive,
-  title={Predictive functional profiling of microbial communities using 16S rRNA marker gene sequences},
+  title={Predictive functional profiling of microbial communities using {16S} {rRNA} marker gene sequences},
   author={Langille, Morgan GI and Zaneveld, Jesse and Caporaso, J Gregory and McDonald, Daniel and Knights, Dan and Reyes, Joshua A and Clemente, Jose C and Burkepile, Deron E and Thurber, Rebecca L Vega and Knight, Rob and Beiko, Robert G and Huttenhower, Curtis},
-  journal={Nature biotechnology},
+  journal={Nature Biotechnology},
   volume={31},
   number={9},
   pages={814--821},
@@ -1272,8 +1305,8 @@ http://www.mdpi.com/1422-0067/10/11/4723/pdf
 
 http://www.annualreviews.org/doi/abs/10.1146/annurev-ecolsys-110411-160307
 @article{fierer2012animalcules,
-  title={From animalcules to an ecosystem: Application of ecological concepts to the human microbiome},
-  author={Fierer, Noah and Ferrenberg, Scott and Flores, Gilberto E and Gonz{\'a}lez, Antonio and Kueneman, Jordan and Legg, Teresa and Lynch, Ryan C and McDonald, Daniel and Mihaljevic, Joseph R and O'Neill, Sean P and others},
+  title={From animalcules to an ecosystem: {A}pplication of ecological concepts to the human microbiome},
+  author={Fierer, Noah and Ferrenberg, Scott and Flores, Gilberto E. and Gonz{\'a}lez, Antonio and Kueneman, Jordan and Legg, Teresa and Lynch, Ryan C. and McDonald, Daniel and Mihaljevic, Joseph R. and O'Neill, Sean P. and Rhodes, Matthew E. and Song, Se Jin and Walters, William A.},
   journal={Annual Review of Ecology, Evolution, and Systematics},
   volume={43},
   pages={137--155},
@@ -1294,13 +1327,24 @@ http://www.sciencemag.org/content/336/6086/1255.short
 }
 
 @article{treangen2013metamos,
-  title={MetAMOS: a modular and open source metagenomic assembly and analysis pipeline},
+  title={{MetAMOS}: {A} modular and open source metagenomic assembly and analysis pipeline},
   author={Treangen, Todd J and Koren, Sergey and Sommer, Daniel D and Liu, Bo and Astrovskaya, Irina and Ondov, Brian and Darling, Aaron E and Phillippy, Adam M and Pop, Mihai},
-  journal={Genome biology},
+  journal={Genome Biology},
   volume={14},
   number={1},
   pages={R2},
   year={2013},
+  publisher={BioMed Central Ltd}
+}
+
+@article{stark2010mltreemap,
+  title={MLTreeMap-accurate Maximum Likelihood placement of environmental DNA sequences into taxonomic and functional reference phylogenies},
+  author={Stark, Manuel and Berger, Simon and Stamatakis, Alexandros and von Mering, Christian},
+  journal={BMC genomics},
+  volume={11},
+  number={1},
+  pages={461},
+  year={2010},
   publisher={BioMed Central Ltd}
 }
 
@@ -1316,9 +1360,9 @@ http://www.sciencemag.org/content/336/6086/1255.short
 }
 
 @article{zaneveld2010ribosomal,
-  title={Ribosomal RNA diversity predicts genome diversity in gut bacteria and their relatives},
+  title={Ribosomal {RNA} diversity predicts genome diversity in gut bacteria and their relatives},
   author={Zaneveld, Jesse R and Lozupone, Catherine and Gordon, Jeffrey I and Knight, Rob},
-  journal={Nucleic acids research},
+  journal={Nucleic Acids Research},
   volume={38},
   number={12},
   pages={3869--3879},
@@ -1327,7 +1371,7 @@ http://www.sciencemag.org/content/336/6086/1255.short
 }
 
 @article{kembel2012incorporating,
-  title={Incorporating 16S Gene Copy Number Information Improves Estimates of Microbial Diversity and Abundance},
+  title={Incorporating {16S} Gene Copy Number Information Improves Estimates of Microbial Diversity and Abundance},
   author={Kembel, Steven W and Wu, Martin and Eisen, Jonathan A and Green, Jessica L},
   journal={PLOS Computational Biology},
   volume={8},
@@ -1348,7 +1392,7 @@ http://www.sciencemag.org/content/336/6086/1255.short
 }
 
 @article{treangen2011metamos,
-  title={MetAMOS: a metagenomic assembly and analysis pipeline for AMOS},
+  title={{MetAMOS}: {A} metagenomic assembly and analysis pipeline for {AMOS}},
   author={Treangen, Todd J and Koren, Sergey and Astrovskaya, Irina and Sommer, Dan and Liu, Bo and Pop, Mihai},
   journal={Genome Biology},
   volume={12},
@@ -1383,7 +1427,7 @@ http://www.sciencemag.org/content/336/6086/1255.short
 @article{jakobsson2010short,
   title={Short-term antibiotic treatment has differing long-term impacts on the human throat and gut microbiome},
   author={Jakobsson, Hedvig E and Jernberg, Cecilia and Andersson, Anders F and Sj{\"o}lund-Karlsson, Maria and Jansson, Janet K and Engstrand, Lars},
-  journal={PLoS One},
+  journal={PLOS ONE},
   volume={5},
   number={3},
   pages={e9836},
@@ -1394,7 +1438,7 @@ http://www.sciencemag.org/content/336/6086/1255.short
 @article{wylie2012sequence,
   title={Sequence analysis of the human virome in febrile and afebrile children},
   author={Wylie, Kristine M and Mihindukulasuriya, Kathie A and Sodergren, Erica and Weinstock, George M and Storch, Gregory A},
-  journal={PLoS One},
+  journal={PLOS ONE},
   volume={7},
   number={6},
   pages={e27735},
@@ -1406,7 +1450,7 @@ url={http://www.ploscollections.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.
 % http://www.biomedcentral.com/content/pdf/gb-2011-12-5-r50.pdf
 @article{caporaso2011moving,
   title={Moving pictures of the human microbiome},
-  author={Caporaso, J Gregory and Lauber, Christian L and Costello, Elizabeth K and Berg-Lyons, Donna and Gonzalez, Antonio and Stombaugh, Jesse and Knights, Dan and Gajer, Pawel and Ravel, Jacques and Fierer, Noah and others},
+  author={Caporaso, J. Gregory and Lauber, Christian L. and Costello, Elizabeth K. and Berg-Lyons, Donna and Gonzalez, Antonio and Stombaugh, Jesse and Knights, Dan and Gajer, Pawel and Ravel, Jacques and Fierer, Noah and Gordon, Jeffrey I. and Knight, Rob},
   journal={Genome Biol},
   volume={12},
   number={5},
@@ -1417,7 +1461,7 @@ url={http://www.ploscollections.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.
 @article{jernberg2007long,
   title={Long-term ecological impacts of antibiotic administration on the human intestinal microbiota},
   author={Jernberg, Cecilia and L{\"o}fmark, Sonja and Edlund, Charlotta and Jansson, Janet K},
-  journal={The ISME journal},
+  journal={The ISME Journal},
   volume={1},
   number={1},
   pages={56--66},
@@ -1437,9 +1481,9 @@ url={http://www.ploscollections.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.
 }
 
 @article{dethlefsen2008pervasive,
-  title={The pervasive effects of an antibiotic on the human gut microbiota, as revealed by deep 16S rRNA sequencing},
+  title={The pervasive effects of an antibiotic on the human gut microbiota, as revealed by deep {16S} {rRNA} sequencing},
   author={Dethlefsen, Les and Huse, Sue and Sogin, Mitchell L and Relman, David A},
-  journal={PLoS biology},
+  journal={PLOS Biology},
   volume={6},
   number={11},
   pages={e280},
@@ -1450,7 +1494,7 @@ url={http://www.ploscollections.org/article/info%3Adoi%2F10.1371%2Fjournal.pone.
 http://www.nature.com/nature/journal/v486/n7402/full/nature11209.html
 @article{methe2012framework,
   title={A framework for human microbiome research},
-  author={Meth{\'e}, Barbara A and Nelson, Karen E and Pop, Mihai and Creasy, Heather H and Giglio, Michelle G and Huttenhower, Curtis and Gevers, Dirk and Petrosino, Joseph F and Abubucker, Sahar and Badger, Jonathan H and others},
+  author={Meth{\'e}, Barbara A. and Nelson, Karen E. and Pop, Mihai and Creasy, Heather H. and Giglio, Michelle G. and Huttenhower, Curtis and Gevers, Dirk and Petrosino, Joseph F. and Abubucker, Sahar and Badger, Jonathan H. and Chinwalla, Asif T. and Earl, Ashlee M. and FitzGerald, Michael G. and Fulton, Robert S. and Hallsworth-Pepin, Kymberlie and Lobos, Elizabeth A. and Madupu, Ramana and Magrini, Vincent and Martin, John C. and Mitreva, Makedonka and Muzny, Donna M. and Sodergren, Erica J. and Versalovic, James and Wollam, Aye M. and Worley, Kim C. and Wortman, Jennifer R. and Young, Sarah K. and Zeng, Qiandong and Aagaard, Kjersti M. and Abolude, Olukemi O. and Allen-Vercoe, Emma and Alm, Eric J. and Alvarado, Lucia and Andersen, Gary L. and Anderson, Scott and Appelbaum, Elizabeth and Arachchi, Harindra M. and Armitage, Gary and Arze, Cesar A. and Ayvaz, Tulin and Baker, Carl C. and Begg, Lisa and Belachew, Tsegahiwot and Bhonagiri, Veena and Bihan, Monika and Blaser, Martin J. and Bloom, Toby and Bonazzi, Vivien R. and Brooks, Paul and Buck, Gregory A. and Buhay, Christian J. and Busam, Dana A. and Campbell, Joseph L. and Canon, Shane R. and Cantarel, Brandi L. and Chain, Patrick S. and Chen, I-Min A. and Chen, Lei and Chhibba, Shaila and Chu, Ken and Ciulla, Dawn M. and Clemente, Jose C. and Clifton, Sandra W. and Conlan, Sean and Crabtree, Jonathan and Cutting, Mary A. and Davidovics, Noam J. and Davis, Catherine C. and DeSantis, Todd Z. and Deal, Carolyn and Delehaunty, Kimberley D. and Dewhirst, Floyd E. and Deych, Elena and Ding, Yan and Dooling, David J. and Dugan, Shannon P. and Michael Dunne, W. and Scott Durkin, A. and Edgar, Robert C. and Erlich, Rachel L. and Farmer, Candace N. and Farrell, Ruth M. and Faust, Karoline and Feldgarden, Michael and Felix, Victor M. and Fisher, Sheila and Fodor, Anthony A. and Forney, Larry and Foster, Leslie and Di Francesco, Valentina and Friedman, Jonathan and Friedrich, Dennis C. and Fronick, Catrina C. and Fulton, Lucinda L. and Gao, Hongyu and Garcia, Nathalia and Giannoukos, Georgia and Giblin, Christina and Giovanni, Maria Y. and Goldberg, Jonathan M. and Goll, Johannes and Gonzalez, Antonio and Griggs, Allison and Gujja, Sharvari and Haas, Brian J. and Hamilton, Holli A. and Harris, Emily L. and Hepburn, Theresa A. and Herter, Brandi and Hoffmann, Diane E. and Holder, Michael E. and Howarth, Clinton and Huang, Katherine H. and Huse, Susan M. and Izard, Jacques and Jansson, Janet K. and Jiang, Huaiyang and Jordan, Catherine and Joshi, Vandita and Katancik, James A. and Keitel, Wendy A. and Kelley, Scott T. and Kells, Cristyn and Kinder-Haake, Susan and King, Nicholas B. and Knight, Rob and Knights, Dan and Kong, Heidi H. and Koren, Omry and Koren, Sergey and Kota, Karthik C. and Kovar, Christie L. and Kyrpides, Nikos C. and La Rosa, Patricio S. and Lee, Sandra L. and Lemon, Katherine P. and Lennon, Niall and Lewis, Cecil M. and Lewis, Lora and Ley, Ruth E. and Li, Kelvin and Liolios, Konstantinos and Liu, Bo and Liu, Yue and Lo, Chien-Chi and Lozupone, Catherine A. and Dwayne Lunsford, R. and Madden, Tessa and Mahurkar, Anup A. and Mannon, Peter J. and Mardis, Elaine R. and Markowitz, Victor M. and Mavrommatis, Konstantinos and McCorrison, Jamison M. and McDonald, Daniel and McEwen, Jean and McGuire, Amy L. and McInnes, Pamela and Mehta, Teena and Mihindukulasuriya, Kathie A. and Miller, Jason R. and Minx, Patrick J. and Newsham, Irene and Nusbaum, Chad and O’Laughlin, Michelle and Orvis, Joshua and Pagani, Ioanna and Palaniappan, Krishna and Patel, Shital M. and Pearson, Matthew and Peterson, Jane and Podar, Mircea and Pohl, Craig and Pollard, Katherine S. and Priest, Margaret E. and Proctor, Lita M. and Qin, Xiang and Raes, Jeroen and Ravel, Jacques and Reid, Jeffrey G. and Rho, Mina and Rhodes, Rosamond and Riehle, Kevin P. and Rivera, Maria C. and Rodriguez-Mueller, Beltran and Rogers, Yu-Hui and Ross, Matthew C. and Russ, Carsten and Sanka, Ravi K. and Sankar, Pamela and Fah Sathirapongsasuti, J. and Schloss, Jeffery A. and Schloss, Patrick D. and Schmidt, Thomas M. and Scholz, Matthew and Schriml, Lynn and Schubert, Alyxandria M. and Segata, Nicola and Segre, Julia A. and Shannon, William D. and Sharp, Richard R. and Sharpton, Thomas J. and Shenoy, Narmada and Sheth, Nihar U. and Simone, Gina A. and Singh, Indresh and Smillie, Chris S. and Sobel, Jack D. and Sommer, Daniel D. and Spicer, Paul and Sutton, Granger G. and Sykes, Sean M. and Tabbaa, Diana G. and Thiagarajan, Mathangi and Tomlinson, Chad M. and Torralba, Manolito and Treangen, Todd J. and Truty, Rebecca M. and Vishnivetskaya, Tatiana A. and Walker, Jason and Wang, Lu and Wang, Zhengyuan and Ward, Doyle V. and Warren, Wesley and Watson, Mark A. and Wellington, Christopher and Wetterstrand, Kris A. and White, James R. and Wilczek-Boney, Katarzyna and Qing Wu, Yuan and Wylie, Kristine M. and Wylie, Todd and Yandava, Chandri and Ye, Liang and Ye, Yuzhen and Yooseph, Shibu and Youmans, Bonnie P. and Zhang, Lan and Zhou, Yanjiao and Zhu, Yiming and Zoloth, Laurie and Zucker, Jeremy D. and Birren, Bruce W. and Gibbs, Richard A. and Highlander, Sarah K. and Weinstock, George M. and Wilson, Richard K. and White, Owen},
   journal={Nature},
   volume={486},
   number={7402},
@@ -1461,7 +1505,7 @@ http://www.nature.com/nature/journal/v486/n7402/full/nature11209.html
 
 @article{chen2012associating,
   title={Associating microbiome composition with environmental
-covariates using generalized UniFrac distances},
+covariates using generalized {UniFrac} distances},
   author={Chen, Jun and Bittinger, Kyle and Charlson, Emily S and
 Hoffmann, Christian and Lewis, James and Wu, Gary D and Collman,
 Ronald G and Bushman, Frederic D and Li, Hongzhe},
@@ -1489,14 +1533,11 @@ Ronald G and Bushman, Frederic D and Li, Hongzhe},
 % SEC software
 
 @article{schloss2009introducing,
-  title={Introducing mothur: open-source, platform-independent,
+  title={Introducing {mothur}: {O}pen-source, platform-independent,
 community-supported software for describing and comparing microbial
 communities},
-  author={Schloss, Patrick D and Westcott, Sarah L and Ryabin, Thomas
-and Hall, Justine R and Hartmann, Martin and Hollister, Emily B and
-Lesniewski, Ryan A and Oakley, Brian B and Parks, Donovan H and
-Robinson, Courtney J and others},
-  journal={Applied and environmental microbiology},
+  author={Schloss, Patrick D. and Westcott, Sarah L. and Ryabin, Thomas and Hall, Justine R. and Hartmann, Martin and Hollister, Emily B. and Lesniewski, Ryan A. and Oakley, Brian B. and Parks, Donovan H. and Robinson, Courtney J. and Sahl, Jason W. and Stres, Blaz and Thallinger, Gerhard G. and Van Horn, David J. and Weber, Carolyn F.},
+  journal={Applied and Environmental Microbiology},
   volume={75},
   number={23},
   pages={7537--7541},
@@ -1505,10 +1546,10 @@ Robinson, Courtney J and others},
 }
 
 @article{lynch2013axiome,
-  title={AXIOME: automated exploration of microbial diversity},
+  title={{AXIOME}: {A}utomated exploration of microbial diversity},
   author={Lynch, Michael DJ and Masella, Andre P and Hall, Michael W
 and Bartram, Andrea K and Neufeld, Josh D},
-  journal={GigaScience},
+  journal={{GigaScience}},
   volume={2},
   number={1},
   pages={3},
@@ -1519,7 +1560,7 @@ and Bartram, Andrea K and Neufeld, Josh D},
 @article{bazinet2012comparative,
   title={A comparative evaluation of sequence classification programs},
   author={Bazinet, A.L. and Cummings, M.P.},
-  journal={BMC bioinformatics},
+  journal={BMC Bioinformatics},
   volume={13},
   number={1},
   pages={92},
@@ -1531,7 +1572,7 @@ and Bartram, Andrea K and Neufeld, Josh D},
 @article{berger2011performance,
 	author = {Berger, S.A. and Krompass, D. and Stamatakis, A.},
 	title = {Performance, accuracy, and web server for evolutionary placement of short sequence reads under maximum likelihood},
-	journal = {Systematic biology},
+	journal = {Systematic Biology},
 	number = {3},
 	pages = {291--302},
 	publisher = {Oxford University Press},
@@ -1559,15 +1600,15 @@ month = jan,
 number = {3},
 pages = {732--7},
 pmid = {16407106},
-title = {{Molecular analysis of the bacterial microbiota in the human stomach.}},
+title = {Molecular analysis of the bacterial microbiota in the human stomach.},
 volume = {103},
 year = {2006}
 }
 
 @article{brady2011phymmbl,
-  title={PhymmBL expanded: confidence scores, custom databases, parallelization and more},
+  title={{PhymmBL} expanded: {C}onfidence scores, custom databases, parallelization and more},
   author={Brady, A. and Salzberg, S.},
-  journal={Nature methods},
+  journal={Nature Methods},
   volume={8},
   number={5},
   pages={367--367},
@@ -1575,21 +1616,10 @@ year = {2006}
   publisher={Nature Publishing Group}
 }
 
-@article{brady2009phymm,
-  title={Phymm and PhymmBL: metagenomic phylogenetic classification with interpolated Markov models},
-  author={Brady, A. and Salzberg, S.L.},
-  journal={Nature methods},
-  volume={6},
-  number={9},
-  pages={673--676},
-  year={2009},
-  publisher={Nature Publishing Group}
-}
-
 @article{caporaso2010qiime,
   title={{QIIME} allows analysis of high-throughput community sequencing data},
-  author={Caporaso, J.G. and Kuczynski, J. and Stombaugh, J. and Bittinger, K. and Bushman, F.D. and Costello, E.K. and Fierer, N. and Pe{\~n}a, A.G. and Goodrich, J.K. and Gordon, J.I. and others},
-  journal={Nature meth},
+  author={Caporaso, J Gregory and Kuczynski, Justin and Stombaugh, Jesse and Bittinger, Kyle and Bushman, Frederic D and Costello, Elizabeth K and Fierer, Noah and Pe{\~n}a, Antonio Gonzalez and Goodrich, Julia K and Gordon, Jeffrey I and Huttley, Gavin A and Kelley, Scott T and Knights, Dan and Koenig, Jeremy E and Ley, Ruth E and Lozupone, Catherine A and McDonald, Daniel and Muegge, Brian D and Pirrung, Meg and Reeder, Jens and Sevinsky, Joel R and Turnbaugh, Peter J and Walters, William A and Widmann, Jeremy and Yatsunenko, Tanya and Zaneveld, Jesse and Knight, Rob},
+  journal={Nature Methods},
   volume={7},
   number={5},
   pages={335--336},
@@ -1598,19 +1628,19 @@ year = {2006}
 }
 
 @Article{case2007rpob,
-   title="{{U}se of 16{S} r{RNA} and rpo{B} genes as molecular markers for microbial ecology studies}",
-   author="Case, R. J.  and Boucher, Y.  and Dahllof, I.  and Holmstrom, C.  and Doolittle, W. F.  and Kjelleberg, S. ",
-   journal="Appl. Environ. Microbiol.",
-   year="2007",
-   volume="73",
-   number="1",
-   pages="278--288",
-   month="Jan"
+   title={Use of {16S} {rRNA} and {rpoB} genes as molecular markers for microbial ecology studies},
+   author={Case, R. J.  and Boucher, Y.  and Dahllof, I.  and Holmstrom, C.  and Doolittle, W. F.  and Kjelleberg, S.},
+   journal={Appl. Environ. Microbiol.},
+   year={2007},
+   volume={73},
+   number={1},
+   pages={278--288},
+   month={Jan}
 }
 
 % Workflow tools
 @article{chao2010phylogenetic,
-  title={Phylogenetic diversity measures based on Hill numbers},
+  title={Phylogenetic diversity measures based on {H}ill numbers},
   author={Chao, A. and Chiu, C.H. and Jost, L.},
   journal={Philosophical Transactions of the Royal Society B: Biological Sciences},
   volume={365},
@@ -1621,23 +1651,23 @@ year = {2006}
 }
 
 @article{chen2010human,
-  title={The Human Oral Microbiome Database: a web accessible resource for investigating oral microbe taxonomic and genomic information},
+  title={The {H}uman {O}ral {M}icrobiome {D}atabase: {A} web accessible resource for investigating oral microbe taxonomic and genomic information},
   author={Chen, T. and Yu, W.H. and Izard, J. and Baranova, O.V. and Lakshmanan, A. and Dewhirst, F.E.},
-  journal={Database: the journal of biological databases and curation},
+  journal={Database: the Journal of Biological Databases and Curation},
   volume={2010},
   year={2010},
   publisher={Oxford University Press}
 }
 
 @Article{clarridge2004,
-   title="{{I}mpact of 16{S} r{RNA} gene sequence analysis for identification of bacteria on clinical microbiology and infectious diseases}",
-   author="Clarridge, J. E. ",
-   journal="Clin. Microbiol. Rev.",
-   year="2004",
-   volume="17",
-   number="4",
-   pages="840--862",
-   month="Oct"
+   title={Impact of {16S} {rRNA} gene sequence analysis for identification of bacteria on clinical microbiology and infectious diseases},
+   author={Clarridge, J. E.},
+   journal={Clin. Microbiol. Rev.},
+   year={2004},
+   volume={17},
+   number={4},
+   pages={840--862},
+   month={Oct}
 }
 
 @article{ColeEaRDP2009,
@@ -1648,26 +1678,15 @@ keywords = {classification},
 number = {Database issue},
 pages = {D141--D145},
 publisher = {Oxford University Press},
-title = {{The Ribosomal Database Project: improved alignments and new tools for rRNA analysis}},
+title = {The {R}ibosomal {D}atabase {P}roject: {I}mproved alignments and new tools for {rRNA} analysis},
 volume = {37},
 year = {2009}
 }
 
-@article{costello2009bacterial,
-  title={Bacterial community variation in human body habitats across space and time},
-  author={Costello, E.K. and Lauber, C.L. and Hamady, M. and Fierer, N. and Gordon, J.I. and Knight, R.},
-  journal={Science},
-  volume={326},
-  number={5960},
-  pages={1694--1697},
-  year={2009},
-  publisher={American Association for the Advancement of Science}
-}
-
 @article{dalevi2007automated,
-  title={Automated group assignment in large phylogenetic trees using GRUNT: GRouping, Ungrouping, Naming Tool},
+  title={Automated group assignment in large phylogenetic trees using {GRUNT}: {GR}ouping, {U}ngrouping, {N}aming {T}ool},
   author={Dalevi, D. and DeSantis, T. and Fredslund, J. and Andersen, G. and Markowitz, V. and Hugenholtz, P.},
-  journal={BMC bioinformatics},
+  journal={BMC Bioinformatics},
   volume={8},
   number={1},
   pages={402},
@@ -1676,7 +1695,7 @@ year = {2009}
 }
 
 @article{desantis2006greengenes,
-  title={{Greengenes, a chimera-checked 16S rRNA gene database and workbench compatible with ARB}},
+  title={{G}reengenes, a chimera-checked {16S} {rRNA} gene database and workbench compatible with {ARB}},
   author={DeSantis, T.Z. and Hugenholtz, P. and Larsen, N. and Rojas, M. and Brodie, E.L. and Keller, K. and Huber, T. and Dalevi, D. and Hu, P. and Andersen, G.L.},
   journal={Applied and Environmental Microbiology},
   volume={72},
@@ -1687,7 +1706,7 @@ year = {2009}
 }
 
 @article{eddy1998profile,
-  title={Profile hidden Markov models.},
+  title={Profile hidden {M}arkov models.},
   author={Eddy, S.R.},
   journal={Bioinformatics},
   volume={14},
@@ -1698,18 +1717,18 @@ year = {2009}
 }
 
 @Article{edgar2010usearch,
-   author="Edgar, R. C. ",
-   title="{{S}earch and clustering orders of magnitude faster than {BLAST}}",
-   journal="Bioinformatics",
-   year="2010",
-   volume="26",
-   number="19",
-   pages="2460--2461",
-   month="Oct"
+   author={Edgar, R. C.},
+   title={Search and clustering orders of magnitude faster than {BLAST}},
+   journal={Bioinformatics},
+   year={2010},
+   volume={26},
+   number={19},
+   pages={2460--2461},
+   month={Oct}
 }
 
 @article{evans2012phylogenetic,
-title = {{The phylogenetic Kantorovich-Rubinstein metric for environmental sequence samples}},
+title = {The phylogenetic {K}antorovich-{R}ubinstein metric for environmental sequence samples},
 author = {Evans, S. N. and Matsen, F. A.},
 journal = {J. Royal Stat. Soc. (B)},
 volume = {74},
@@ -1726,9 +1745,9 @@ year = {2012}
 }
 
 @article{felsenstein1981evolutionary,
-  title={{Evolutionary trees from DNA sequences: a maximum likelihood approach}},
+  title={Evolutionary trees from {DNA} sequences: {A} maximum likelihood approach},
   author={Felsenstein, J.},
-  journal={Journal of molecular evolution},
+  journal={Journal of Molecular Evolution},
   volume={17},
   number={6},
   pages={368--376},
@@ -1737,7 +1756,7 @@ year = {2012}
 }
 
 @article{forey2001phylocode,
-  title={{The PhyloCode: description and commentary}},
+  title={The {PhyloCode}: {D}escription and commentary},
   author={Forey, P.L.},
   journal={Bulletin of Zoological Nomenclature},
   volume={58},
@@ -1757,9 +1776,9 @@ year = {2012}
 	year = {2005}}
 
 @article{griffen2011core,
-  title={CORE: a phylogenetically-curated 16S rDNA database of the core oral microbiome},
+  title={{CORE}: {A} phylogenetically-curated {16S} {rDNA} database of the core oral microbiome},
   author={Griffen, A.L. and Beall, C.J. and Firestone, N.D. and Gross, E.L. and DiFranco, J.M. and Hardman, J.H. and Vriesendorp, B. and Faust, R.A. and Janies, D.A. and Leys, E.J.},
-  journal={PloS One},
+  journal={PLOS ONE},
   volume={6},
   number={4},
   pages={e19051},
@@ -1768,7 +1787,7 @@ year = {2012}
 }
 
 @article{hill1973diversity,
-  title={Diversity and evenness: a unifying notation and its consequences},
+  title={Diversity and evenness: {A} unifying notation and its consequences},
   author={Hill, M.O.},
   journal={Ecology},
   volume={54},
@@ -1779,19 +1798,19 @@ year = {2012}
 }
 
 @Article{hugenholtz2002review,
-   title="{{E}xploring prokaryotic diversity in the genomic era}",
-   author="Hugenholtz, P. ",
-   journal="Genome Biol.",
-   year="2002",
-   volume="3",
-   number="2",
-   pages="REVIEWS0003"
+   title={Exploring prokaryotic diversity in the genomic era},
+   author={Hugenholtz, P.},
+   journal={Genome Biol.},
+   year={2002},
+   volume={3},
+   number={2},
+   pages={REVIEWS0003}
 }
 
 @article{hummelen2010deep,
-  title={Deep sequencing of the vaginal microbiota of women with HIV},
+  title={Deep sequencing of the vaginal microbiota of women with {HIV}},
   author={Hummelen, R. and Fernandes, A.D. and Macklaim, J.M. and Dickson, R.J. and Changalucha, J. and Gloor, G.B. and Reid, G.},
-  journal={PLoS One},
+  journal={PLOS ONE},
   volume={5},
   number={8},
   pages={e12078},
@@ -1799,22 +1818,10 @@ year = {2012}
   publisher={Public Library of Science}
 }
 
-@article{huson2007megan,
-	author = {Huson, D.H. and Auch, A.F. and Qi, J. and Schuster, S.C.},
-	journal = {Genome research},
-	number = {3},
-	pages = {377--386},
-	publisher = {Cold Spring Harbor Lab},
-	title = {{MEGAN} analysis of metagenomic data},
-	volume = {17},
-	year = {2007}
-}
-
-http://www.ploscompbiol.org/article/info%3Adoi%2F10.1371%2Fjournal.pcbi.1002832
 @article{o2012phylogenetic,
   title={Phylogenetic diversity theory sheds light on the structure of microbial communities},
   author={O'Dwyer, James P and Kembel, Steven W and Green, Jessica L},
-  journal={PLOS computational biology},
+  journal={PLOS Computational Biology},
   volume={8},
   number={12},
   pages={e1002832},
@@ -1833,14 +1840,14 @@ http://www.ploscompbiol.org/article/info%3Adoi%2F10.1371%2Fjournal.pcbi.1002832
 }
 
 @Article{carma,
-   author="Krause, L.  and Diaz, N. N.  and Goesmann, A.  and Kelley, S.  and Nattkemper, T. W.  and Rohwer, F.  and Edwards, R. A.  and Stoye, J. ",
-   title="{{P}hylogenetic classification of short environmental {D}{N}{A} fragments}",
-   journal="Nucleic Acids Res.",
-   year="2008",
-   volume="36",
-   number="7",
-   pages="2230--2239",
-   month="Apr"
+   author={Krause, L.  and Diaz, N. N.  and Goesmann, A.  and Kelley, S.  and Nattkemper, T. W.  and Rohwer, F.  and Edwards, R. A.  and Stoye, J.},
+   title={Phylogenetic classification of short environmental {DNA} fragments},
+   journal={Nucleic Acids Res.},
+   year={2008},
+   volume={36},
+   number={7},
+   pages={2230--2239},
+   month={Apr}
 }
 
 @book{kreig1984bergey,
@@ -1853,7 +1860,7 @@ http://www.ploscompbiol.org/article/info%3Adoi%2F10.1371%2Fjournal.pcbi.1002832
 @article{kuczynski2010microbial,
   title={Microbial community resemblance methods differ in their ability to detect biologically relevant patterns},
   author={Kuczynski, J. and Liu, Z. and Lozupone, C. and McDonald, D. and Fierer, N. and Knight, R.},
-  journal={Nature methods},
+  journal={Nature Methods},
   year={2010},
   pages={813--819},
   volume={7},
@@ -1861,9 +1868,9 @@ http://www.ploscompbiol.org/article/info%3Adoi%2F10.1371%2Fjournal.pcbi.1002832
 }
 
 @article{lan2012using,
-  title={Using the RDP Classifier to Predict Taxonomic Novelty and Reduce the Search Space for Finding Novel Organisms},
+  title={Using the {RDP} Classifier to Predict Taxonomic Novelty and Reduce the Search Space for Finding Novel Organisms},
   author={Lan, Y. and Wang, Q. and Cole, J.R. and Rosen, G.L.},
-  journal={PLoS ONE},
+  journal={PLOS ONE},
   volume={7},
   number={3},
   pages={e32491},
@@ -1872,9 +1879,9 @@ http://www.ploscompbiol.org/article/info%3Adoi%2F10.1371%2Fjournal.pcbi.1002832
 }
 
 @article{zupancic2012analysis,
-  title={Analysis of the gut microbiota in the old order {Amish} and its relation to the metabolic syndrome},
+  title={Analysis of the gut microbiota in the old order {A}mish and its relation to the metabolic syndrome},
   author={Zupancic, Margaret L and Cantarel, Brandi L and Liu, Zhenqiu and Drabek, Elliott F and Ryan, Kathleen A and Cirimotich, Shana and Jones, Cheron and Knight, Rob and Walters, William A and Knights, Daniel and Emmanuel F. Mongodin and Richard B. Horenstein and Braxton D. Mitchell and Nanette Steinle and Soren Snitker and Alan R. Shuldiner and Claire M. Fraser},
-  journal={PLOS One},
+  journal={PLOS ONE},
   volume={7},
   number={8},
   pages={e43052},
@@ -1894,7 +1901,7 @@ http://www.ploscompbiol.org/article/info%3Adoi%2F10.1371%2Fjournal.pcbi.1002832
 }
 
 @article{ley2006microbial,
-  title={Microbial ecology: human gut microbes associated with obesity},
+  title={Microbial ecology: {H}uman gut microbes associated with obesity},
   author={Ley, R.E. and Turnbaugh, P.J. and Klein, S. and Gordon, J.I.},
   journal={Nature},
   volume={444},
@@ -1905,25 +1912,14 @@ http://www.ploscompbiol.org/article/info%3Adoi%2F10.1371%2Fjournal.pcbi.1002832
 }
 
 @Article{li2006cdhit,
-   author="Li, W.  and Godzik, A.",
-   title="{{C}d-hit: a fast program for clustering and comparing large sets of protein or nucleotide sequences}",
-   journal="Bioinformatics",
-   year="2006",
-   volume="22",
-   number="13",
-   pages="1658--1659",
-   month="Jul"
-}
-
-@article{liu2008accurate,
-  title={Accurate taxonomy assignments from 16S rRNA sequences produced by highly parallel pyrosequencers},
-  author={Liu, Z. and DeSantis, T.Z. and Andersen, G.L. and Knight, R.},
-  journal={Nucleic acids research},
-  volume={36},
-  number={18},
-  pages={e120--e120},
-  year={2008},
-  publisher={Oxford Univ Press}
+   author={Li, W.  and Godzik, A.},
+   title={{Cd-hit}: {A} fast program for clustering and comparing large sets of protein or nucleotide sequences},
+   journal={Bioinformatics},
+   year={2006},
+   volume={22},
+   number={13},
+   pages={1658--1659},
+   month={Jul}
 }
 
 @article{LozuponeEaWeightedUnifrac07,
@@ -1933,7 +1929,7 @@ journal = {Appl. Environ. Microbiol.},
 number = {5},
 pages = {1576--85},
 pmid = {17220268},
-title = {{Quantitative and qualitative beta diversity measures lead to different insights into factors that structure microbial communities.}},
+title = {Quantitative and qualitative beta diversity measures lead to different insights into factors that structure microbial communities.},
 volume = {73},
 year = {2007}
 }
@@ -1946,15 +1942,15 @@ journal = {Appl. Environ. Microbiol.},
 number = {12},
 pages = {8228},
 publisher = {Am Soc Microbiol},
-title = {{UniFrac: a new phylogenetic method for comparing microbial communities}},
+title = {{UniFrac}: {A} new phylogenetic method for comparing microbial communities},
 volume = {71},
 year = {2005}
 }
 
 @article{ludwig2004arb,
-  title={{{ARB}: a software environment for sequence data}},
-  author={Ludwig, W. and Strunk, O. and Westram, R. and Richter, L. and Meier, H. and others},
-  journal={Nucleic acids res},
+  title={{ARB}: {A} software environment for sequence data},
+  author={Ludwig, Wolfgang and Strunk, Oliver and Westram, Ralf and Richter, Lothar and Meier, Harald and Yadhukumar and Buchner, Arno and Lai, Tina and Steppi, Susanne and Jobb, Gangolf and Förster, Wolfram and Brettske, Igor and Gerber, Stefan and Ginhart, Anton W. and Gross, Oliver and Grumann, Silke and Hermann, Stefan and Jost, Ralf and König, Andreas and Liss, Thomas and Lüßmann, Ralph and May, Michael and Nonhoff, Björn and Reichel, Boris and Strehlow, Robert and Stamatakis, Alexandros and Stuckmann, Norbert and Vilbig, Alexander and Lenke, Michael and Ludwig, Thomas and Bode, Arndt and Schleifer, Karl‐Heinz},
+  journal={Nucleic Acids Res},
   volume={32},
   number={4},
   pages={1363},
@@ -1972,7 +1968,7 @@ year = {2005}
 }
 
 @article{maidak1997rdp,
-  title={The RDP (ribosomal database project)},
+  title={The {RDP} (ribosomal database project)},
   author={Maidak, B.L. and Olsen, G.J. and Larsen, N. and Overbeek, R. and McCaughey, M.J. and Woese, C.R.},
   journal={Nucleic Acids Research},
   volume={25},
@@ -1983,7 +1979,7 @@ year = {2005}
 }
 
 @article{matsen2013edge,
-  title={Edge principal components and squash clustering: using the special structure of phylogenetic placement data for sample comparison},
+  title={Edge principal components and squash clustering: {U}sing the special structure of phylogenetic placement data for sample comparison},
   author={Matsen, Frederick A and Evans, Steven N},
   journal={PLOS ONE},
   volume={8},
@@ -1994,7 +1990,7 @@ year = {2005}
 }
 
 @article{matsen2012reconciling,
-  title={Reconciling taxonomy and phylogenetic inference: formalism and algorithms for describing discord and inferring taxonomic roots},
+  title={Reconciling taxonomy and phylogenetic inference: {F}ormalism and algorithms for describing discord and inferring taxonomic roots},
   author={Matsen, F. A. and Gallagher, A.},
   journal={Algorithms for Molecular Biology},
   volume={7},
@@ -2007,18 +2003,18 @@ year = {2005}
 
 @article{matsen2010pplacer,
 	author = {Matsen, F.A. and Kodner, R.B. and Armbrust, E.V.},
-	journal = {BMC bioinformatics},
+	journal = {BMC Bioinformatics},
 	number = {1},
 	pages = {538},
 	publisher = {BioMed Central Ltd},
-	title = {pplacer: linear time maximum-likelihood and Bayesian phylogenetic placement of sequences onto a fixed reference tree},
+	title = {{pplacer}: {L}inear time maximum-likelihood and {B}ayesian phylogenetic placement of sequences onto a fixed reference tree},
 	volume = {11},
 	year = {2010}}
 
 @article{mcdonald2011improved,
-  title={An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea},
+  title={An improved {G}reengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea},
   author={McDonald, Daniel and Price, Morgan N and Goodrich, Julia and Nawrocki, Eric P and DeSantis, Todd Z and Probst, Alexander and Andersen, Gary L and Knight, Rob and Hugenholtz, Philip},
-  journal={The ISME journal},
+  journal={The ISME Journal},
   volume={6},
   number={3},
   pages={610--618},
@@ -2027,29 +2023,29 @@ year = {2005}
 }
 
 @Article{phylopythia,
-   author="McHardy, A. C.  and Martin, H. G.  and Tsirigos, A.  and Hugenholtz, P.  and Rigoutsos, I. ",
-   title="{{A}ccurate phylogenetic classification of variable-length {D}{N}{A} fragments}",
-   journal="Nat. Methods",
-   year="2007",
-   volume="4",
-   number="1",
-   pages="63--72",
-   month="Jan"
+   author={McHardy, A. C.  and Martin, H. G.  and Tsirigos, A.  and Hugenholtz, P.  and Rigoutsos, I.},
+   title={Accurate phylogenetic classification of variable-length {DNA} fragments},
+   journal={Nat. Methods},
+   year={2007},
+   volume={4},
+   number={1},
+   pages={63--72},
+   month={Jan}
 }
 
 @Article{mcnabb2004hsp65,
-   title="{{A}ssessment of partial sequencing of the 65-kilodalton heat shock protein gene (hsp65) for routine identification of {M}ycobacterium species isolated from clinical sources}",
-   author="McNabb, A.  and Eisler, D.  and Adie, K.  and Amos, M.  and Rodrigues, M.  and Stephens, G.  and Black, W. A.  and Isaac-Renton, J. ",
-   journal="J. Clin. Microbiol.",
-   year="2004",
-   volume="42",
-   number="7",
-   pages="3000--3011",
-   month="Jul"
+   title={Assessment of partial sequencing of the 65-kilodalton heat shock protein gene ({hsp65}) for routine identification of {M}ycobacterium species isolated from clinical sources},
+   author={McNabb, A.  and Eisler, D.  and Adie, K.  and Amos, M.  and Rodrigues, M.  and Stephens, G.  and Black, W. A.  and Isaac-Renton, J.},
+   journal={J. Clin. Microbiol.},
+   year={2004},
+   volume={42},
+   number={7},
+   pages={3000--3011},
+   month={Jul}
 }
 
 @article{mirarabsepp,
-  title={{SEPP: SAT{\'e}-Enabled Phylogenetic Placement}},
+  title={{SEPP}: {SAT\'e}-Enabled Phylogenetic Placement},
   author={Mirarab, S. and Nguyen, N. and Warnow, T.},
   journal={Accepted to the Pacific Symposium on Biocomputing},
   year={2012},
@@ -2063,13 +2059,13 @@ journal = {Bioinformatics},
 keywords = {Animals,Data Interpretation,Databases,Environmental Microbiology,Genetic,Genome,Genomics,Genomics: methods,Humans,Software,Statistical},
 number = {15},
 pages = {1849--55},
-title = {{Visual and statistical comparison of metagenomes.}},
+title = {Visual and statistical comparison of metagenomes.},
 volume = {25},
 year = {2009}
 }
 
 @article{monierEaLargeViruses08,
-  title={{Taxonomic distribution of large DNA viruses in the sea}},
+  title={Taxonomic distribution of large {DNA} viruses in the sea},
   author={Monier, A. and Claverie, J.M. and Ogata, H.},
   journal={Genome Biol},
   volume={9},
@@ -2081,7 +2077,7 @@ year = {2009}
 @article{morgan2010metagenomic,
   title={Metagenomic sequencing of an in vitro-simulated microbial community},
   author={Morgan, Jenna L and Darling, Aaron E and Eisen, Jonathan A},
-  journal={PLoS One},
+  journal={PLOS ONE},
   volume={5},
   number={4},
   pages={e10209},
@@ -2111,7 +2107,7 @@ year = {2009}
 }
 
 @article{nawrocki2009infernal,
-  title={Infernal 1.0: inference of RNA alignments},
+  title={{I}nfernal 1.0: {I}nference of {RNA} alignments},
   author={Nawrocki, E.P. and Kolbe, D.L. and Eddy, S.R.},
   journal={Bioinformatics},
   volume={25},
@@ -2135,7 +2131,7 @@ year = {2009}
 @article{parks2011classifying,
   title={Classifying short genomic fragments from novel lineages using composition and homology},
   author={Parks, D. and MacDonald, N. and Beiko, R.},
-  journal={BMC bioinformatics},
+  journal={BMC Bioinformatics},
   volume={12},
   number={1},
   pages={328},
@@ -2155,9 +2151,9 @@ year = {2009}
 }
 
 @article{price2010fasttree,
-  title={{FastTree 2--approximately maximum-likelihood trees for large alignments}},
+  title={{FastTree} 2--approximately maximum-likelihood trees for large alignments},
   author={Price, M.N. and Dehal, P.S. and Arkin, A.P.},
-  journal={PLOS One},
+  journal={PLOS ONE},
   volume={5},
   number={3},
   pages={e9490},
@@ -2169,13 +2165,13 @@ author = {Purdom, E},
 journal = {UC Berkeley Statistics Technical Reports},
 volume = {766},
 pages = {1--22},
-title = {{Analyzing data with graphs: Metagenomic data and the phylogenetic tree}},
+title = {Analyzing data with graphs: {M}etagenomic data and the phylogenetic tree},
 year = {2008}
 }
 
 @article{ravel2011vaginal,
   title={Vaginal microbiome of reproductive-age women},
-  author={Ravel, J. and Gajer, P. and Abdo, Z. and Schneider, G.M. and Koenig, S.S.K. and McCulle, S.L. and Karlebach, S. and Gorle, R. and Russell, J. and Tacket, C.O. and others},
+  author={Ravel, Jacques and Gajer, Pawel and Abdo, Zaid and Schneider, G. Maria and Koenig, Sara S. K. and McCulle, Stacey L. and Karlebach, Shara and Gorle, Reshma and Russell, Jennifer and Tacket, Carol O. and Brotman, Rebecca M. and Davis, Catherine C. and Ault, Kevin and Peralta, Ligia and Forney, Larry J.},
   journal={Proceedings of the National Academy of Sciences},
   volume={108},
   number={Supplement 1},
@@ -2185,7 +2181,7 @@ year = {2008}
 }
 
 @article{rosen2011nbc,
-  title={NBC: the Naive Bayes Classification tool webserver for taxonomic classification of metagenomic reads},
+  title={{NBC}: {T}he {N}aive {B}ayes {C}lassification tool webserver for taxonomic classification of metagenomic reads},
   author={Rosen, G.L. and Reichenberger, E.R. and Rosenfeld, A.M.},
   journal={Bioinformatics},
   volume={27},
@@ -2217,28 +2213,17 @@ year = {2008}
 }
 
 @article{srinivasan2012bacterial,
-	author = {Srinivasan, S. and Hoffman, N.G. and Morgan, M.T. and Matsen, F.A. and Fiedler, T.L. and Hall, R.W. and Ross, F.J. and McCoy, C.O. and Bumgarner, R. and Marrazzo, J.M. and others},
+    author = {Srinivasan, Sujatha and Hoffman, Noah G. and Morgan, Martin T. and Matsen, Frederick A. and Fiedler, Tina L. and Hall, Robert W. and Ross, Frederick J. and McCoy, Connor O. and Bumgarner, Roger and Marrazzo, Jeanne M. and Fredricks, David N.},
 	journal = {PLOS ONE},
 	number = {6},
 	pages = {e37818},
 	publisher = {Public Library of Science},
-	title = {Bacterial communities in women with bacterial vaginosis: high resolution phylogenetic analyses reveal relationships of microbiota to clinical criteria},
+	title = {Bacterial communities in women with bacterial vaginosis: {H}igh resolution phylogenetic analyses reveal relationships of microbiota to clinical criteria},
 	volume = {7},
 	year = {2012}}
 
-@article{stark2010mltreemap,
-  title={{{MLTreeMap}-accurate Maximum Likelihood placement of environmental DNA sequences into taxonomic and functional reference phylogenies.}},
-  author={Stark, M. and Berger, S. and Stamatakis, A. and von Mering, C.},
-  journal={BMC genomics},
-  volume={11},
-  number={1},
-  pages={461},
-  year={2010},
-  publisher={BioMed Central Ltd}
-}
-
 @article{turnbaugh2008core,
-	author = {Turnbaugh, P.J. and Hamady, M. and Yatsunenko, T. and Cantarel, B.L. and Duncan, A. and Ley, R.E. and Sogin, M.L. and Jones, W.J. and Roe, B.A. and Affourtit, J.P. and others},
+    author = {Turnbaugh, Peter J. and Hamady, Micah and Yatsunenko, Tanya and Cantarel, Brandi L. and Duncan, Alexis and Ley, Ruth E. and Sogin, Mitchell L. and Jones, William J. and Roe, Bruce A. and Affourtit, Jason P. and Egholm, Michael and Henrissat, Bernard and Heath, Andrew C. and Knight, Rob and Gordon, Jeffrey I.},
 	journal = {Nature},
 	number = {7228},
 	pages = {480--484},
@@ -2248,7 +2233,7 @@ year = {2008}
 	year = {2008}}
 
 @article{vonMeringEaQuantitative08,
-  title={{Quantitative phylogenetic assessment of microbial communities in diverse environments}},
+  title={Quantitative phylogenetic assessment of microbial communities in diverse environments},
   author={Von Mering, C. and Hugenholtz, P. and Raes, J. and Tringe, SG and Doerks, T. and Jensen, LJ and Ward, N. and Bork, P.},
   journal={Science},
   volume={315},
@@ -2259,9 +2244,9 @@ year = {2008}
 }
 
 @article{wang2007naive,
-  title={{Naive Bayesian classifier for rapid assignment of rRNA sequences into the new bacterial taxonomy}},
+  title={Naive {B}ayesian classifier for rapid assignment of {rRNA} sequences into the new bacterial taxonomy},
   author={Wang, Q. and Garrity, G.M. and Tiedje, J.M. and Cole, J.R.},
-  journal={Applied and environmental microbiology},
+  journal={Applied and Environmental Microbiology},
   volume={73},
   number={16},
   pages={5261--5267},
@@ -2270,7 +2255,7 @@ year = {2008}
 }
 
 @article{werner2011impact,
-  title={Impact of training sets on classification of high-throughput bacterial 16s rRNA gene surveys},
+  title={Impact of training sets on classification of high-throughput bacterial {16S} {rRNA} gene surveys},
   author={Werner, J.J. and Koren, O. and Hugenholtz, P. and DeSantis, T.Z. and Walters, W.A. and Caporaso, J.G. and Angenent, L.T. and Knight, R. and Ley, R.E.},
   journal={The ISME Journal},
   volume={6},
@@ -2283,7 +2268,7 @@ year = {2008}
 @article{white2010alignment,
   title={Alignment and clustering of phylogenetic markers-implications for microbial diversity studies},
   author={White, J. and Navlakha, S. and Nagarajan, N. and Ghodsi, M.R. and Kingsford, C. and Pop, M.},
-  journal={BMC bioinformatics},
+  journal={BMC Bioinformatics},
   volume={11},
   number={1},
   pages={152},
@@ -2292,19 +2277,19 @@ year = {2008}
 }
 
 @Article{wu2008amphora,
-   author="Wu, M.  and Eisen, J. A.",
-   title="{{A} simple, fast, and accurate method of phylogenomic inference}",
-   journal="Genome Biol.",
-   year="2008",
-   volume="9",
-   number="10",
-   pages="R151"
+   author={Wu, M.  and Eisen, J. A.},
+   title={A simple, fast, and accurate method of phylogenomic inference},
+   journal={Genome Biol.},
+   year={2008},
+   volume={9},
+   number={10},
+   pages={R151}
 }
 
 @article{wu2008simple,
   title={A simple, fast, and accurate method of phylogenomic inference},
   author={Wu, M. and Eisen, J.A.},
-  journal={Genome biol},
+  journal={Genome Biol},
   volume={9},
   number={10},
   pages={1--11},
@@ -2336,7 +2321,7 @@ year = {2008}
 @article{grice2009topographical,
   title={Topographical and temporal diversity of the human skin microbiome},
   author={Grice, Elizabeth A and Kong, Heidi H and Conlan, Sean and Deming, Clayton B and Davis, Joie and Young, Alice C and Bouffard, Gerard G and Blakesley, Robert W and Murray, Patrick R and Green, Eric D and Maria L. Turner and Julia A. Segre},
-  journal={science},
+  journal={Science},
   volume={324},
   number={5931},
   pages={1190--1192},
@@ -2347,7 +2332,7 @@ year = {2008}
 http://www.nature.com/news/gut-microbial-enterotypes-become-less-clear-cut-1.10276
 @article{arumugam2011enterotypes,
   title={Enterotypes of the human gut microbiome},
-  author={Arumugam, Manimozhiyan and Raes, Jeroen and Pelletier, Eric and Le Paslier, Denis and Yamada, Takuji and Mende, Daniel R and Fernandes, Gabriel R and Tap, Julien and Bruls, Thomas and Batto, Jean-Michel and others},
+  author={Arumugam, Manimozhiyan and Raes, Jeroen and Pelletier, Eric and Le Paslier, Denis and Yamada, Takuji and Mende, Daniel R. and Fernandes, Gabriel R. and Tap, Julien and Bruls, Thomas and Batto, Jean-Michel and Bertalan, Marcelo and Borruel, Natalia and Casellas, Francesc and Fernandez, Leyden and Gautier, Laurent and Hansen, Torben and Hattori, Masahira and Hayashi, Tetsuya and Kleerebezem, Michiel and Kurokawa, Ken and Leclerc, Marion and Levenez, Florence and Manichanh, Chaysavanh and Nielsen, H. Bjorn and Nielsen, Trine and Pons, Nicolas and Poulain, Julie and Qin, Junjie and Sicheritz-Ponten, Thomas and Tims, Sebastian and Torrents, David and Ugarte, Edgardo and Zoetendal, Erwin G. and Wang, Jun and Guarner, Francisco and Pedersen, Oluf and de Vos, Willem M. and Brunak, Soren and Dore, Joel and Weissenbach, Jean and Ehrlich, S. Dusko and Bork, Peer},
   journal={Nature},
   volume={473},
   number={7346},
@@ -2369,9 +2354,9 @@ https://www.sciencemag.org/content/334/6052/105.short
 }
 
 @article{gough2011systematic,
-  title={Systematic review of intestinal microbiota transplantation (fecal bacteriotherapy) for recurrent Clostridium difficile infection},
+  title={Systematic review of intestinal microbiota transplantation (fecal bacteriotherapy) for recurrent {C}lostridium difficile infection},
   author={Gough, Ethan and Shaikh, Henna and Manges, Amee R},
-  journal={Clinical infectious diseases},
+  journal={Clinical Infectious Diseases},
   volume={53},
   number={10},
   pages={994--1002},
@@ -2380,7 +2365,7 @@ https://www.sciencemag.org/content/334/6052/105.short
 }
 
 @article{wu2009phylogeny,
-  title={A phylogeny-driven genomic encyclopaedia of Bacteria and Archaea},
+  title={A phylogeny-driven genomic encyclopaedia of {B}acteria and {A}rchaea},
   author={Wu, Dongying and Hugenholtz, Philip and Mavromatis, Konstantinos and Pukall, R{\"u}diger and Dalin, Eileen and Ivanova, Natalia N and Kunin, Victor and Goodwin, Lynne and Wu, Martin and Tindall, Brian J and Sean D. Hooper and Amrita Pati and Athanasios Lykidis and Stefan Spring and Iain J. Anderson and Patrik D’haeseleer and Adam Zemla and Mitchell Singer and Alla Lapidus and Matt Nolan and Alex Copeland and Cliff Han and Feng Chen and Jan-Fang Cheng and Susan Lucas and Cheryl Kerfeld and Elke Lang and Sabine Gronow and Patrick Chain and David Bruce and Edward M. Rubin and Nikos C. Kyrpides and Hans-Peter Klenk and Jonathan A. Eisen},
   journal={Nature},
   volume={462},
@@ -2394,7 +2379,7 @@ http://www.ploscompbiol.org/article/info%3Adoi%2F10.1371%2Fjournal.pcbi.1002808
 
 @article{claesson2012gut,
   title={Gut microbiota composition correlates with diet and health in the elderly},
-  author={Claesson, Marcus J and Jeffery, Ian B and Conde, Susana and Power, Susan E and O’Connor, Eibhl{\'\i}s M and Cusack, Siobh{\'a}n and Harris, Hugh MB and Coakley, Mairead and Lakshminarayanan, Bhuvaneswari and O’Sullivan, Orla and others},
+  author={Claesson, Marcus J. and Jeffery, Ian B. and Conde, Susana and Power, Susan E. and O'Connor, Eibhl{\'\i}s M. and Cusack, Siobh{\'a}n and Harris, Hugh M. B. and Coakley, Mairead and Lakshminarayanan, Bhuvaneswari and O'Sullivan, Orla and Fitzgerald, Gerald F. and Deane, Jennifer and O'Connor, Michael and Harnedy, Norma and O'Connor, Kieran and O'Mahony, Denis and van Sinderen, Douwe and Wallace, Martina and Brennan, Lorraine and Stanton, Catherine and Marchesi, Julian R. and Fitzgerald, Anthony P. and Shanahan, Fergus and Hill, Colin and Ross, R. Paul and O'Toole, Paul W.},
   journal={Nature},
   volume={488},
   number={7410},

--- a/sbreview.tex
+++ b/sbreview.tex
@@ -503,7 +503,7 @@ I am also grateful to Aaron Darling, David Fredricks, Noah Hoffman, Steven Kembe
 \newpage
 }
 
-\bibliographystyle{plainnat}
+\bibliographystyle{plainnat_abbrv}
 \bibliography{sbreview}
 
 \end{document}


### PR DESCRIPTION
- replaced full lists of authors where Google Scholar had truncated to "and others", per author guidelines
- added capitalization protection where needed
- switched the few articles that were using quotes to curly braces
- removed a few duplicate articles
- fixed journal name capitalization where needed
